### PR TITLE
Add support to unpause stats if diapered

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "dependencies": {
     "@emotion/styled": "^11.14.1",
     "@preact/signals": "^2.0.1",
-    "@rollup/rollup-linux-x64-gnu": "^4.44.2",
     "@types/lodash-es": "^4.17.12",
     "eventemitter3": "^5.0.1",
     "preact": "^10.26.4",

--- a/src/core/player/player.ts
+++ b/src/core/player/player.ts
@@ -60,7 +60,19 @@ export const abclPlayer = {
   },
   /** once per minute */
   update: () => {
-    if (Player.ABCL.Settings.PauseStats) return;
+    if (Player.ABCL.Settings.PauseStats)
+    {
+      if (Player.ABCL.Settings.UnPauseStatsWhenDiapered && hasDiaper())
+      {
+        // re-enable stats if the player has a diaper on, since they can still have accidents
+        Player.ABCL.Settings.PauseStats = false;
+      }
+      else
+      {
+        return;
+      }
+    }
+
     bowelThrottler.allowedCallInterval = (120 * 1000) / Math.max(0.1, MetabolismSettingValues[Player.ABCL.Settings.PoopMetabolism]);
     bladderThrottler.allowedCallInterval = (120 * 1000) / Math.max(0.1, MetabolismSettingValues[Player.ABCL.Settings.PeeMetabolism]);
 

--- a/src/core/player/player.ts
+++ b/src/core/player/player.ts
@@ -62,15 +62,10 @@ export const abclPlayer = {
   update: () => {
     if (Player.ABCL.Settings.PauseStats)
     {
-      if (Player.ABCL.Settings.UnPauseStatsWhenDiapered && hasDiaper())
-      {
-        // re-enable stats if the player has a diaper on, since they can still have accidents
-        Player.ABCL.Settings.PauseStats = false;
-      }
-      else
-      {
-        return;
-      }
+      if (!Player.ABCL.Settings.UnPauseStatsWhenDiapered || !hasDiaper()) return;
+
+      // re-enable stats if the player has a diaper on, since they can still have accidents
+      Player.ABCL.Settings.PauseStats = false;
     }
 
     bowelThrottler.allowedCallInterval = (120 * 1000) / Math.max(0.1, MetabolismSettingValues[Player.ABCL.Settings.PoopMetabolism]);

--- a/src/core/settings.ts
+++ b/src/core/settings.ts
@@ -54,6 +54,7 @@ export const defaultSettings: ModSettings = {
   CanUsePotty: true,
   CanChangeDiapers: true,
   DisableParticles: false,
+  UnPauseStatsWhenDiapered: true,
 };
 
 export const defaultStats: ModStats = {
@@ -138,6 +139,7 @@ export const defaultSettingPermissions: ModStorageModel["SettingPermissions"] = 
   CanUsePotty: false,
   CanChangeDiapers: false,
   DisableParticles: false,
+  UnPauseStatsWhenDiapered: true,
 };
 
 const defaultData: ModStorageModel = {

--- a/src/docs/readme.md
+++ b/src/docs/readme.md
@@ -1,1 +1,59 @@
-Here should wiki be and development information
+ABCL repository: https://github.com/zoe-64/ABCL
+
+Majority of BC addons are coded in Typescript, you will need to install node and probably an IDE, you need a github account.
+
+To contribute to a repository:
+
+1. Fork the repository
+Press "Fork" button on the repository page
+
+2. Clone the repository
+```sh
+git clone https://github.com/user/repository.git
+```
+
+3. Install dependancies
+```sh
+npm install
+```
+or your prefered package manager.
+
+4. Run / build the addon
+At this stage you should be able to run build scripts and run scripts
+
+```sh
+npm run watch
+```
+Will build and serve a scipt on http://localhost:3041
+
+You can then use a ViolentMonkey / TamperMonkey usersript to load your dev version:
+```js
+// ==UserScript==
+// @name ABCL (Loader)
+// @namespace https://www.bondageprojects.com/
+// @version Beta
+// @description An addon for [Bondage Club](https://www.bondageprojects.com/club_game/). Stands for "Adult baby club lover"~
+// @author Zoe, Maple, En
+// @match https://*.bondageprojects.elementfx.com/R*/*
+// @match https://*.bondage-europe.com/R*/*
+// @match https://*.bondageprojects.com/R*/*
+// @match http://localhost:*/*
+// @icon  https://zoe-64.github.io/ABCL/versions/beta/assets/favicon.ico
+// @grant none
+// @run-at document-end
+// ==/UserScript==
+
+(function () {
+  "use strict";
+  const src = `http://127.0.0.1:3041/abcl.js?v=${Date.now()}`;
+  if (typeof ABCL_Loaded === "undefined") {
+    const script = document.createElement("script");
+    script.src = src;
+    script.type = "text/javascript";
+    script.crossOrigin = "anonymous";
+    document.head.appendChild(script);
+  }
+})();
+```
+
+**Do not run unstable code on your main account and disable the normal addon if you have it enabled!**

--- a/src/docs/readme.md
+++ b/src/docs/readme.md
@@ -8,9 +8,6 @@ To contribute to a repository:
 Press "Fork" button on the repository page
 
 2. Clone the repository
-```sh
-git clone https://github.com/user/repository.git
-```
 
 3. Install dependancies
 ```sh

--- a/src/screens/Settings/pages/shared-settings.tsx
+++ b/src/screens/Settings/pages/shared-settings.tsx
@@ -18,6 +18,7 @@ export default function SharedSettingsPage({ setPage, selectedCharacter }: { set
   const [mentalMetabolism, setMentalMetabolism] = useState<MetabolismSetting>(selectedCharacter.ABCL.Settings.MentalRegressionModifier);
   const [diaperChangePromptSetting, setDiaperChangePromptSetting] = useState<DiaperChangePromptSetting>(selectedCharacter.ABCL.Settings.OnDiaperChange);
   const [pauseStats, setPauseStats] = useState<boolean>(selectedCharacter.ABCL.Settings.PauseStats);
+  const [unPauseStatsWhenDiapered, setUnPauseStatsWhenDiapered] = useState<boolean>(selectedCharacter.ABCL.Settings.UnPauseStatsWhenDiapered);
   const [disableWettingLeaks, setDisableWettingLeaks] = useState<boolean>(selectedCharacter.ABCL.Settings.DisableWettingLeaks);
   const [disableSoilingLeaks, setDisableSoilingLeaks] = useState<boolean>(selectedCharacter.ABCL.Settings.DisableSoilingLeaks);
   const [disableClothingStains, setDisableClothingStains] = useState<boolean>(selectedCharacter.ABCL.Settings.DisableClothingStains);
@@ -35,6 +36,7 @@ export default function SharedSettingsPage({ setPage, selectedCharacter }: { set
   const [poopMetabolismLocked, setPoopMetabolismLocked] = useState<boolean>(selectedCharacter.ABCL.SettingPermissions.PoopMetabolism);
   const [mentalMetabolismLocked, setMentalMetabolismLocked] = useState<boolean>(selectedCharacter.ABCL.SettingPermissions.MentalRegressionModifier);
   const [diaperChangePromptSettingLocked, setDiaperChangePromptSettingLocked] = useState<boolean>(selectedCharacter.ABCL.SettingPermissions.OnDiaperChange);
+  const [unPauseStatsWhenDiaperedLocked, setUnPauseStatsWhenDiaperedLocked] = useState<boolean>(selectedCharacter.ABCL.SettingPermissions.UnPauseStatsWhenDiapered);
   const [pauseStatsLocked, setPauseStatsLocked] = useState<boolean>(selectedCharacter.ABCL.SettingPermissions.PauseStats);
   const [disableWettingLeaksLocked, setDisableWettingLeaksLocked] = useState<boolean>(selectedCharacter.ABCL.SettingPermissions.DisableWettingLeaks);
   const [disableSoilingLeaksLocked, setDisableSoilingLeaksLocked] = useState<boolean>(selectedCharacter.ABCL.SettingPermissions.DisableSoilingLeaks);
@@ -70,6 +72,7 @@ export default function SharedSettingsPage({ setPage, selectedCharacter }: { set
           settingsRemote.emit(selectedCharacter.MemberNumber, "updateSettings", {
             settings: {
               PauseStats: pauseStats,
+              UnPauseStatsWhenDiapered: unPauseStatsWhenDiapered,
               PeeMetabolism: peeMetabolism,
               PoopMetabolism: poopMetabolism,
               MentalRegressionModifier: mentalMetabolism,
@@ -89,6 +92,7 @@ export default function SharedSettingsPage({ setPage, selectedCharacter }: { set
             },
             settingPermissions: {
               PauseStats: pauseStatsLocked,
+              UnPauseStatsWhenDiapered: unPauseStatsWhenDiaperedLocked,
               PeeMetabolism: peeMetabolismLocked,
               PoopMetabolism: poopMetabolismLocked,
               MentalRegressionModifier: mentalMetabolismLocked,
@@ -113,6 +117,9 @@ export default function SharedSettingsPage({ setPage, selectedCharacter }: { set
       <Group>
         <SettingPanel title="Pause Stats">
           <Checkbox checked={pauseStats} setChecked={setPauseStats} locked={pauseStatsLocked} setLocked={setPauseStatsLocked} />
+        </SettingPanel>
+        <SettingPanel title="UnPause Stats When Diapered">
+          <Checkbox checked={unPauseStatsWhenDiapered} setChecked={setUnPauseStatsWhenDiapered} locked={unPauseStatsWhenDiaperedLocked} setLocked={setUnPauseStatsWhenDiaperedLocked} />
         </SettingPanel>
         <SettingPanel title="Wetting Leaks / Puddles">
           <Checkbox

--- a/src/screens/Settings/pages/stats.tsx
+++ b/src/screens/Settings/pages/stats.tsx
@@ -1,16 +1,16 @@
 import { h } from "preact";
 
-import { ButtonGroup } from "../../components/buttonGroup";
-import { Checkbox } from "../../components/checkbox";
+import styled from "@emotion/styled";
 import { useState } from "preact/hooks";
-import { SettingPanel } from "src/screens/components/settingPanel";
+import { isOwned } from "src/core/player/diaper";
+import { clearData } from "src/core/settings";
 import { MetabolismBar } from "src/screens/components/metabolismDropDown";
 import { Group, Stack } from "src/screens/components/positionComponents";
-import { SettingsH2 } from "../settingsPage";
-import { clearData } from "src/core/settings";
-import styled from "@emotion/styled";
-import { isOwned } from "src/core/player/diaper";
+import { SettingPanel } from "src/screens/components/settingPanel";
 import { RuleId } from "src/types/definitions";
+import { ButtonGroup } from "../../components/buttonGroup";
+import { Checkbox } from "../../components/checkbox";
+import { SettingsH2 } from "../settingsPage";
 
 const ResetButton = styled.button`
   background-color: var(--abcl-warning-color);
@@ -34,6 +34,8 @@ export default function StatsPage({ setPage }: { setPage: (page: string) => void
 
   const [pauseStats, setPauseStats] = useState<boolean>(Player.ABCL.Settings.PauseStats);
   const [pauseStatsLocked, _setPauseStatsLocked] = useState<boolean>(Player.ABCL.SettingPermissions.PauseStats);
+  const [unPauseStatsWhenDiapered, setUnPauseStatsWhenDiapered] = useState<boolean>(Player.ABCL.Settings.UnPauseStatsWhenDiapered);
+  const [unPauseStatsWhenDiaperedLocked, _setUnPauseStatsWhenDiaperedLocked] = useState<boolean>(Player.ABCL.SettingPermissions.UnPauseStatsWhenDiapered);
   const [disableWettingLeaks, setDisableWettingLeaks] = useState<boolean>(Player.ABCL.Settings.DisableWettingLeaks);
   const [disableWettingLeaksLocked, _setDisableWettingLeaksLocked] = useState<boolean>(Player.ABCL.SettingPermissions.DisableWettingLeaks);
   const [disableSoilingLeaks, setDisableSoilingLeaks] = useState<boolean>(Player.ABCL.Settings.DisableSoilingLeaks);
@@ -58,6 +60,7 @@ export default function StatsPage({ setPage }: { setPage: (page: string) => void
         onClick={() => {
           setPage("menu");
           Player.ABCL.Settings.PauseStats = pauseStats;
+          Player.ABCL.Settings.UnPauseStatsWhenDiapered = unPauseStatsWhenDiapered;
           Player.ABCL.Settings.DisableWettingLeaks = disableWettingLeaks;
           Player.ABCL.Settings.DisableSoilingLeaks = disableSoilingLeaks;
           Player.ABCL.Settings.DisableClothingStains = disableClothingStains;
@@ -78,6 +81,9 @@ export default function StatsPage({ setPage }: { setPage: (page: string) => void
       <Group>
         <SettingPanel title="Pause Stats">
           <Checkbox checked={pauseStats} setChecked={setPauseStats} locked={pauseStatsLocked && isOwned()} opaqueLock={true} />
+        </SettingPanel>
+        <SettingPanel title="Resume Stats When Diapered">
+          <Checkbox checked={unPauseStatsWhenDiapered} setChecked={setUnPauseStatsWhenDiapered} locked={unPauseStatsWhenDiaperedLocked && isOwned()} opaqueLock={true} />
         </SettingPanel>
         <SettingPanel title="Wetting Leaks / Puddles">
           <Checkbox checked={disableWettingLeaks} setChecked={setDisableWettingLeaks} locked={disableWettingLeaksLocked && isOwned()} opaqueLock inverted />

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -64,6 +64,7 @@ interface ModSettings {
   CanCheckDiaperWithRestraints: boolean;
   CanUseToilet: boolean;
   CanUsePotty: boolean;
+  UnPauseStatsWhenDiapered: boolean;
 }
 interface ModStats {
   PuddleSize: {


### PR DESCRIPTION
## Changelog
Added a preference to resume stats whenever you get diapered

## Description
If you get diapered (by yourself, or otherwise), and you enable the option, your stats will automatically resume

Also removed a dependency that isn't required for build, and actually stops building on non linux-x64 platforms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a setting to automatically resume statistics when a diaper is present.
  * Added the setting to the statistics and shared settings pages, including permission controls.
  * Enabled this behavior by default.

* **Documentation**
  * Added contributor guidance covering setup, building, local testing, and safety precautions.

* **Bug Fixes**
  * Improved paused-statistics handling based on the new setting and diaper status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->