### PR TITLE
Fixed activities, option to change minigame and bugs

### DIFF
--- a/src/changelog/2.3.18.txt
+++ b/src/changelog/2.3.18.txt
@@ -1,0 +1,4 @@
+Added an option to switch back to the old minigame
+Adjusted the diaper verbs to be more appropriate
+Fixed not being able to change yourself (if you are a big girl)
+Fixed an issue where everyone was stuck at 80% regression~

--- a/src/core/actionLoader.ts
+++ b/src/core/actionLoader.ts
@@ -31,14 +31,15 @@ class Activity {
     public onClick?: (player: Character, group: AssetGroupItemName) => void,
     private target?: AssetGroupItemName[],
     private targetSelf?: AssetGroupItemName[],
-    private criteria?: (player: Character) => { success: boolean; message?: string },
+    private criteria?: (player: Character, silent?: boolean) => { success: boolean; message?: string },
+    /* when should this activity be shown in the menu */
+    private insertionCriteria?: (player: Character) => { success: boolean; message?: string },
   ) {}
 
   fitsCriteria(player: Character, focusGroup: AssetGroupItemName): boolean {
-    return Boolean(
-      (!this.criteria || this.criteria(player).success) &&
-      (this.target?.includes(focusGroup) || (this.targetSelf?.includes(focusGroup) && Player.MemberNumber === player?.MemberNumber)),
-    );
+    if (!(this.target?.includes(focusGroup) || (this.targetSelf?.includes(focusGroup) && Player.MemberNumber === player?.MemberNumber))) return false;
+    if (this.insertionCriteria?.(player)?.success) return true;
+    return Boolean(!this.criteria || this.criteria(player, true).success);
   }
 
   createButton(): HTMLButtonElement {
@@ -53,7 +54,7 @@ class Activity {
       const player = CurrentCharacter?.FocusGroup ? CurrentCharacter : Player;
       const focusGroup = player?.FocusGroup?.Name;
       if (!this.onClick || !focusGroup) return;
-      this.onClick(player, focusGroup);
+      if (Boolean(!this.criteria || this.criteria(player).success)) this.onClick(player, focusGroup);
       DialogLeave();
     });
 
@@ -90,7 +91,8 @@ export const initActions = (): void => {
         activity.OnClick,
         activity.Target,
         activity.TargetSelf,
-        activity.Criteria,
+        activity.Criteria?.bind(activity),
+        activity.InsertCriteria?.bind(activity),
       );
       if (activityInstance.fitsCriteria(player, focusGroup)) {
         if (!Activity.isInserted(activity.ID)) {

--- a/src/core/actions/changeDiaper.ts
+++ b/src/core/actions/changeDiaper.ts
@@ -3,6 +3,7 @@ import { sendDataToAction } from "../hooks";
 import { hasDiaper, isDiaperLocked, updateDiaperColor } from "../player/diaper";
 import { abclPlayer } from "../player/player";
 import { getCharacter, getCharacterName, isABCLPlayer, replace_template, sendABCLAction, targetInputExtractor } from "../player/playerUtils";
+import { sendChatLocal } from "../utils";
 
 export const changeDiaperRequest = (player: Character, force?: boolean) => {
   if (!abclPlayer.settings.CanChangeSelf && player.MemberNumber === Player.MemberNumber) {
@@ -47,44 +48,39 @@ export const changeDiaper: CombinedAction = {
     Image: `${publicURL}/activity/changeDiaper.svg`,
     Target: ["ItemPelvis"],
     OnClick: (player: Character, group: AssetGroupItemName) => changeDiaperRequest(player),
-    Criteria: (player: Character) => {
-      if (!hasDiaper(player))
-        return {
-          success: false,
-          message: "They are not diapered.",
-        };
-      if (isDiaperLocked(player))
-        return {
-          success: false,
-          message: "Diaper is locked.",
-        };
-      if (!isABCLPlayer(player))
-        return {
-          success: false,
-          message: "They are not an ABCL player.",
-        };
-      if (Player.IsRestrained())
-        return {
-          success: false,
-          message: "You are restrained.",
-        };
-      const item = InventoryGet(player, "ItemDevices");
-      if (!(item && ["MedicalBed", "ChangingTable", "Bed", "床左边", "床右边"].includes(item.Asset.Name)))
-        return {
-          success: false,
-          message: "They are not on a changing table or a flat surface.",
-        };
+    InsertCriteria: function (player: Character) {
+      let message = null;
+      if (!isABCLPlayer(player)) message ??= "They are not an ABCL player.";
+      if (isDiaperLocked(player)) message ??= "Diaper is locked.";
+      if (!hasDiaper(player)) message ??= "They are not diapered.";
 
       return {
-        success: true,
+        success: message == null,
+        message: message == null ? undefined : message,
+      };
+    },
+    Criteria: function (player: Character, silent?: boolean) {
+      const result = this.InsertCriteria?.(player) ?? null;
+      let message = result?.message ?? null;
+
+      const item = InventoryGet(player, "ItemDevices");
+      if (item?.Asset.Name != "ChangingTable" && Player.IsRestrained()) message ??= "You are restrained.";
+      if (!(item && ["MedicalBed", "ChangingTable", "Bed", "床左边", "床右边"].includes(item.Asset.Name)))
+        message ??= "They are not on a changing table or a flat surface.";
+
+      if (!silent && message) sendChatLocal(message);
+      return {
+        success: message == null,
+        message: message == null ? undefined : message,
       };
     },
   },
   command: {
     Tag: "change-diaper",
-    Action: (args, msg, parsed) => {
+    Action: function (args, msg, parsed) {
       const character = targetInputExtractor(parsed) ?? Player;
-      if (!changeDiaper.activity!.Criteria!(character).success) return;
+      const result = changeDiaper.activity!.Criteria!(character);
+      if (!result.success) return;
 
       changeDiaperRequest(character);
     },

--- a/src/core/actions/checkDiaper.ts
+++ b/src/core/actions/checkDiaper.ts
@@ -3,7 +3,7 @@ import { hasDiaper } from "../player/diaper";
 import { abclPlayer } from "../player/player";
 import { isABCLPlayer, replace_template, sendABCLAction, targetInputExtractor } from "../player/playerUtils";
 import { abclStatsWindow, resizeElements } from "../player/ui";
-import { getElement } from "../utils";
+import { getElement, sendChatLocal } from "../utils";
 
 export const diaperCheckFunction = (player: Character) => {
   const isSelf = player.MemberNumber === Player.MemberNumber;
@@ -28,19 +28,23 @@ export const checkDiaper: CombinedAction = {
     Image: `${publicURL}/activity/diaperCheck.png`,
     OnClick: (player: Character, group: AssetGroupItemName) => diaperCheckFunction(player),
     Target: ["ItemPelvis"],
-    Criteria: (player: Character) => {
-      if (!isABCLPlayer(player))
-        return {
-          success: false,
-          message: "They are not an ABCL player.",
-        };
-      if (Player.IsRestrained() && !abclPlayer.settings.CanCheckDiaperWithRestraints)
-        return {
-          success: false,
-          message: "You are restrained.",
-        };
+    InsertCriteria: function (player: Character) {
+      let message = null;
+      if (!isABCLPlayer(player)) message ??= "They are not an ABCL player.";
       return {
-        success: true,
+        success: message == null,
+        message: message == null ? undefined : message,
+      };
+    },
+    Criteria: function (player: Character, silent?: boolean) {
+      const result = this.InsertCriteria?.(player) ?? null;
+      let message = result?.message ?? null;
+
+      if (Player.IsRestrained() && !abclPlayer.settings.CanCheckDiaperWithRestraints) message ??= "You are restrained.";
+      if (!silent && message) sendChatLocal(message);
+      return {
+        success: message == null,
+        message: message == null ? undefined : message,
       };
     },
   },

--- a/src/core/actions/diaperFaceRub.ts
+++ b/src/core/actions/diaperFaceRub.ts
@@ -3,6 +3,7 @@ import { sendDataToAction } from "../hooks";
 import { hasDiaper } from "../player/diaper";
 import { abclPlayer } from "../player/player";
 import { getCharacter, isABCLPlayer, replace_template, sendABCLAction } from "../player/playerUtils";
+import { sendChatLocal } from "../utils";
 
 const diaperFaceRubRequest = (player: Character) => {
   if (player.MemberNumber !== Player.MemberNumber) {
@@ -33,29 +34,24 @@ export const diaperFaceRub: CombinedAction = {
     Image: `${publicURL}/activity/diaperFaceRub.png`,
     Target: ["ItemNose"],
     OnClick: (player: Character, group: AssetGroupItemName) => diaperFaceRubRequest(player),
-    Criteria: (player: Character) => {
-      if (!isABCLPlayer(player))
-        return {
-          success: false,
-          message: "They are not an ABCL player.",
-        };
-      if (Player.IsRestrained())
-        return {
-          success: false,
-          message: "You are restrained.",
-        };
-      if (!hasDiaper(Player))
-        return {
-          success: false,
-          message: "You are not diapered.",
-        };
-      if (player.MemberNumber === Player.MemberNumber)
-        return {
-          success: false,
-          message: "You can't rub your own diaper against your face.",
-        };
+    InsertCriteria: function (player: Character) {
+      let message = null;
+      if (!isABCLPlayer(player)) message ??= "They are not an ABCL player.";
+      if (!hasDiaper(Player)) message ??= "You are not diapered.";
+      if (player.MemberNumber === Player.MemberNumber) message ??= "You can't rub your own diaper against your face.";
       return {
-        success: true,
+        success: message == null,
+        message: message == null ? undefined : message,
+      };
+    },
+    Criteria: function (player: Character, silent?: boolean) {
+      const result = this.InsertCriteria?.(player) ?? null;
+      let message = result?.message ?? null;
+      if (Player.IsRestrained()) message ??= "You are restrained.";
+      if (!silent && message) sendChatLocal(message);
+      return {
+        success: message == null,
+        message: message == null ? undefined : message,
       };
     },
   },

--- a/src/core/actions/diaperFaceSit.ts
+++ b/src/core/actions/diaperFaceSit.ts
@@ -3,6 +3,7 @@ import { sendDataToAction } from "../hooks";
 import { hasDiaper } from "../player/diaper";
 import { abclPlayer } from "../player/player";
 import { getCharacter, isABCLPlayer, replace_template, sendABCLAction } from "../player/playerUtils";
+import { sendChatLocal } from "../utils";
 
 const diaperFaceSitRequest = (player: Character) => {
   if (player.MemberNumber !== Player.MemberNumber) {
@@ -34,25 +35,24 @@ export const diaperFaceSit: CombinedAction = {
     Image: `${publicURL}/activity/diaperFaceSit.png`,
     Target: ["ItemNose"],
     OnClick: (player: Character, group: AssetGroupItemName) => diaperFaceSitRequest(player),
-    Criteria: (player: Character) => {
-      if (!isABCLPlayer(player)) return {
-        success: false,
-        message: "They are not an ABCL player.",
-      };
-      if (Player.IsRestrained()) return {
-        success: false,
-        message: "You are restrained.",
-      };
-      if (!hasDiaper(Player)) return {
-        success: false,
-        message: "You are not diapered.",
-      };
-      if (player.MemberNumber === Player.MemberNumber) return {
-        success: false,
-        message: "You can't sit with your own diaper on your face.",
-      }
+    InsertCriteria: function (player: Character) {
+      let message = null;
+      if (!isABCLPlayer(player)) message ??= "They are not an ABCL player.";
+      if (!hasDiaper(Player)) message ??= "You are not diapered.";
+      if (player.MemberNumber === Player.MemberNumber) message = "You can't sit with your own diaper on your face.";
       return {
-        success: true,
+        success: message == null,
+        message: message == null ? undefined : message,
+      };
+    },
+    Criteria: function (player: Character, silent?: boolean) {
+      const result = this.InsertCriteria?.(player) ?? null;
+      let message = result?.message ?? null;
+      if (Player.IsRestrained()) message ??= "You are restrained.";
+      if (!silent && message) sendChatLocal(message);
+      return {
+        success: message == null,
+        message: message == null ? undefined : message,
       };
     },
   },

--- a/src/core/actions/diaperPatBack.ts
+++ b/src/core/actions/diaperPatBack.ts
@@ -2,6 +2,7 @@ import { CombinedAction } from "../../types/types";
 import { sendDataToAction } from "../hooks";
 import { getDiaperVerb, hasDiaper } from "../player/diaper";
 import { getCharacter, isABCLPlayer, replace_template, sendABCLAction } from "../player/playerUtils";
+import { sendChatLocal } from "../utils";
 
 const diaperPatBackRequest = (player: Character) => {
   if (player.MemberNumber !== Player.MemberNumber) return sendDataToAction("diaper-pat-back", undefined, player.MemberNumber);
@@ -29,24 +30,23 @@ export const diaperPatBack: CombinedAction = {
     Image: `${publicURL}/activity/diaperPatBack.png`,
     Target: ["ItemButt"],
     OnClick: (player: Character, group: AssetGroupItemName) => diaperPatBackRequest(player),
-    Criteria: (player: Character) => {
-      if (!isABCLPlayer(player))
-        return {
-          success: false,
-          message: "They are not an ABCL player.",
-        };
-      if (Player.IsRestrained())
-        return {
-          success: false,
-          message: "You are restrained.",
-        };
-      if (!hasDiaper(player))
-        return {
-          success: false,
-          message: "They are not diapered.",
-        };
+    InsertCriteria: function (player: Character) {
+      let message = null;
+      if (!isABCLPlayer(player)) message ??= "They are not an ABCL player.";
+      if (!hasDiaper(player)) message ??= "They are not diapered.";
       return {
-        success: true,
+        success: message == null,
+        message: message == null ? undefined : message,
+      };
+    },
+    Criteria: function (player: Character, silent?: boolean) {
+      const result = this.InsertCriteria?.(player) ?? null;
+      let message = result?.message ?? null;
+      if (Player.IsRestrained()) message ??= "You are restrained.";
+      if (!silent && message) sendChatLocal(message);
+      return {
+        success: message == null,
+        message: message == null ? undefined : message,
       };
     },
   },

--- a/src/core/actions/diaperPatFront.ts
+++ b/src/core/actions/diaperPatFront.ts
@@ -29,23 +29,17 @@ export const diaperPatFront: CombinedAction = {
     Image: `${publicURL}/activity/diaperPatFront.png`,
     Target: ["ItemVulva"],
     OnClick: (player: Character, group: AssetGroupItemName) => diaperPatFrontRequest(player),
-    Criteria: (player: Character) => {
-      if (!isABCLPlayer(player)) return {
-        success: false,
-        message: "They are not an ABCL player.",
-      }
-      if (Player.IsRestrained()) return {
-        success: false,
-        message: "You are restrained.",
-      }
-      if (!hasDiaper(player)) return {
-        success: false,
-        message: "They are not diapered.",
-      }
+    Criteria: function (player: Character, silent?: boolean) {
+      const result = this.InsertCriteria?.(player) ?? null;
+      let message = result?.message ?? null;
+      if (!isABCLPlayer(player)) message = "They are not an ABCL player.";
+      if (Player.IsRestrained()) message = "You are restrained.";
+      if (!hasDiaper(player)) message = "They are not diapered.";
       return {
-        success: true,
-      }
-    }
+        success: message == null,
+        message: message == null ? undefined : message,
+      };
+    },
   },
   listeners: {
     "diaper-pat-front": ({ Sender }) => diaperPatFrontFunction(getCharacter(Sender!) ?? Player),

--- a/src/core/actions/diaperPeeOthersDiaper.ts
+++ b/src/core/actions/diaperPeeOthersDiaper.ts
@@ -3,6 +3,7 @@ import { sendDataToAction } from "../hooks";
 import { hasDiaper } from "../player/diaper";
 import { abclPlayer } from "../player/player";
 import { getCharacter, isABCLPlayer, replace_template, sendABCLAction } from "../player/playerUtils";
+import { sendChatLocal } from "../utils";
 
 const diaperPeeOthersDiaperRequest = (player: Character, volume: number) => {
   if (player.MemberNumber !== Player.MemberNumber) return sendDataToAction("diaper-pee-others-diaper", { volume: volume }, player.MemberNumber);
@@ -31,31 +32,29 @@ export const diaperPeeOthersDiaper: CombinedAction = {
     Image: `${publicURL}/activity/diaperPeeOthersDiaper.png`,
     Target: ["ItemPelvis"],
     OnClick: (player: Character, group: AssetGroupItemName) => diaperPeeOthersDiaperRequest(player, abclPlayer.stats.BladderValue),
-    Criteria: (player: Character) =>{
-      if (!isABCLPlayer(player)) return {
-        success: false,
-        message: "They are not an ABCL player.",
-      }
-      if (Player.IsRestrained()) return {
-        success: false,
-        message: "You are restrained.",
-      }
-      if (!hasDiaper(player)) return {
-        success: false,
-        message: "They are not diapered.",
-      }
-      if (player === Player) return {
-        success: false,
-        message: "You can't pee in your own diaper.", // that's a funny one
-      }
-      if (abclPlayer.stats.BladderValue <= 0) return {
-        success: false,
-        message: "Your bladder is empty.",
-      }
+    InsertCriteria: function (player: Character) {
+      let message = null;
+      if (!isABCLPlayer(player)) message ??= "They are not an ABCL player.";
+      if (!hasDiaper(player)) message ??= "They are not diapered.";
       return {
-        success: true,
+        success: message == null,
+        message: message == null ? undefined : message,
       };
-    }},
+    },
+    Criteria: function (player: Character, silent?: boolean) {
+      const result = this.InsertCriteria?.(player) ?? null;
+      let message = result?.message ?? null;
+      if (Player.IsRestrained()) message ??= "You are restrained.";
+      if (player === Player) message ??= "You can't pee in your own diaper."; // that's a funny one
+      if (abclPlayer.stats.BladderFullness < 0.15) message ??= "Your bladder is empty.";
+
+      if (!silent && message) sendChatLocal(message);
+      return {
+        success: message == null,
+        message: message == null ? undefined : message,
+      };
+    },
+  },
   listeners: {
     "diaper-pee-others-diaper": ({ Sender }, { volume }) => diaperPeeOthersDiaperFunction(getCharacter(Sender!) ?? Player, volume),
   },

--- a/src/core/actions/diaperPour.ts
+++ b/src/core/actions/diaperPour.ts
@@ -3,6 +3,7 @@ import { sendDataToAction } from "../hooks";
 import { hasDiaper } from "../player/diaper";
 import { abclPlayer } from "../player/player";
 import { getCharacter, isABCLPlayer, replace_template, sendABCLAction } from "../player/playerUtils";
+import { sendChatLocal } from "../utils";
 
 const diaperPourRequest = (player: Character) => {
   if (player.MemberNumber !== Player.MemberNumber) return sendDataToAction("diaper-pour", undefined, player.MemberNumber);
@@ -35,24 +36,23 @@ export const diaperPour: CombinedAction = {
     Image: `${publicURL}/activity/diaperPour.png`,
     Target: ["ItemPelvis"],
     OnClick: (player: Character, group: AssetGroupItemName) => diaperPourRequest(player),
-    Criteria: (player: Character) => {
-      if (!isABCLPlayer(player))
-        return {
-          success: false,
-          message: "They are not an ABCL player.",
-        };
-      if (Player.IsRestrained())
-        return {
-          success: false,
-          message: "You are restrained.",
-        };
-      if (!hasDiaper(player))
-        return {
-          success: false,
-          message: "They are not diapered.",
-        };
+    InsertCriteria: function (player: Character) {
+      let message = null;
+      if (!isABCLPlayer(player)) message ??= "They are not an ABCL player.";
+      if (!hasDiaper(player)) message ??= "They are not diapered.";
       return {
-        success: true,
+        success: message == null,
+        message: message == null ? undefined : message,
+      };
+    },
+    Criteria: function (player: Character, silent?: boolean) {
+      const result = this.InsertCriteria?.(player) ?? null;
+      let message = result?.message ?? null;
+      if (Player.IsRestrained()) message ??= "You are restrained.";
+      if (!silent && message) sendChatLocal(message);
+      return {
+        success: message == null,
+        message: message == null ? undefined : message,
       };
     },
   },

--- a/src/core/actions/diaperRubBack.ts
+++ b/src/core/actions/diaperRubBack.ts
@@ -14,7 +14,7 @@ export const diaperRubBackFunction = (player: Character) => {
   const diaperSound = diaperVerb === "dry" ? "crinkles" : "sloshes";
   const isSelf = player.MemberNumber === Player.MemberNumber;
   const selfMessage = `%NAME% blushes as %PRONOUN% rubs %POSSESSIVE% ${diaperVerb} diapered butt with both hands, breath hitching at the soft ${diaperSound} under %POSSESSIVE% hands.`;
-  const otherMessage = `%OPP_NAME% runs %OPP_POSSESSIVE% hand over %NAME%'s ${diaperVerb} diapered butt, rubbing affectionate circles into the ${diaperVerb} padding.`;
+  const otherMessage = `%OPP_NAME% runs %OPP_POSSESSIVE% hand over %NAME%'s ${diaperVerb} diapered butt, rubbing affectionate circles into the padding.`;
   sendABCLAction(replace_template(isSelf ? selfMessage : otherMessage, player), undefined, "playerActivity", player);
   ActivityEffectFlat(Player, Player, 5, "ItemButt", 1);
   if (abclPlayer.stats.Incontinence > Math.random()) {
@@ -35,24 +35,24 @@ export const diaperRubBack: CombinedAction = {
     Image: `${publicURL}/activity/diaperRubBack.png`,
     Target: ["ItemButt"],
     OnClick: (player: Character, group: AssetGroupItemName) => diaperRubBackRequest(player),
-    Criteria: (player: Character) => {
-      if (!isABCLPlayer(player)) return {
-        success: false,
-        message: "They are not an ABCL player.",
-      }
-      if (Player.IsRestrained()) return {
-        success: false,
-        message: "You are restrained.",
-      }
-      if (!hasDiaper(player)) return {
-        success: false,
-        message: "They are not diapered.",
-      }
+    InsertCriteria: function (player: Character) {
+      let message = null;
+      if (!isABCLPlayer(player)) message ??= "They are not an ABCL player.";
+      if (!hasDiaper(player)) message ??= "They are not diapered.";
       return {
-        success: true,
-      }
-    }
-      
+        success: message == null,
+        message: message == null ? undefined : message,
+      };
+    },
+    Criteria: function (player: Character, silent?: boolean) {
+      const result = this.InsertCriteria?.(player) ?? null;
+      let message = result?.message ?? null;
+      if (Player.IsRestrained()) message = "You are restrained.";
+      return {
+        success: message == null,
+        message: message == null ? undefined : message,
+      };
+    },
   },
   listeners: {
     "diaper-rub-back": ({ Sender }) => diaperRubBackFunction(getCharacter(Sender!) ?? Player),

--- a/src/core/actions/diaperRubFront.ts
+++ b/src/core/actions/diaperRubFront.ts
@@ -3,6 +3,7 @@ import { sendDataToAction } from "../hooks";
 import { getDiaperVerb, hasDiaper } from "../player/diaper";
 import { abclPlayer } from "../player/player";
 import { getCharacter, isABCLPlayer, replace_template, sendABCLAction } from "../player/playerUtils";
+import { sendChatLocal } from "../utils";
 
 const diaperRubFrontRequest = (player: Character) => {
   if (player.MemberNumber !== Player.MemberNumber) return sendDataToAction("diaper-rub-front", undefined, player.MemberNumber);
@@ -13,7 +14,7 @@ export const diaperRubFrontFunction = (player: Character) => {
   const diaperVerb = getDiaperVerb(Player);
   const isSelf = player.MemberNumber === Player.MemberNumber;
   const selfMessage = `%NAME% blushes as %PRONOUN% rubs circles over the front of %POSSESSIVE% ${diaperVerb} diaper, biting %POSSESSIVE% lip as %PRONOUN% grinds down into %POSSESSIVE% own hand.`;
-  const otherMessage = `%OPP_NAME% rubs up and down %NAME%'s ${diaperVerb} diaper, %OPP_POSSESSIVE% fingers pressing into the ${diaperVerb} padding over the front and between %POSSESSIVE% legs.`;
+  const otherMessage = `%OPP_NAME% rubs up and down %NAME%'s diaper, %OPP_POSSESSIVE% fingers pressing into the ${diaperVerb} padding over the front and between %POSSESSIVE% legs.`;
   sendABCLAction(replace_template(isSelf ? selfMessage : otherMessage, player), undefined, "playerActivity", player);
   ActivityEffectFlat(Player, Player, 10, "ItemVulva", 1);
   if (abclPlayer.stats.Incontinence > Math.random()) {
@@ -34,24 +35,23 @@ export const diaperRubFront: CombinedAction = {
     Image: `${publicURL}/activity/diaperRubFront.png`,
     Target: ["ItemVulva"],
     OnClick: (player: Character, group: AssetGroupItemName) => diaperRubFrontRequest(player),
-    Criteria: (player: Character) => {
-      if (!isABCLPlayer(player))
-        return {
-          success: false,
-          message: "They are not an ABCL player.",
-        };
-      if (Player.IsRestrained())
-        return {
-          success: false,
-          message: "You are restrained.",
-        };
-      if (!hasDiaper(player))
-        return {
-          success: false,
-          message: "They are not diapered.",
-        };
+    InsertCriteria: function (player: Character) {
+      let message = null;
+      if (!isABCLPlayer(player)) message ??= "They are not an ABCL player.";
+      if (!hasDiaper(player)) message ??= "They are not diapered.";
       return {
-        success: true,
+        success: message == null,
+        message: message == null ? undefined : message,
+      };
+    },
+    Criteria: function (player: Character, silent?: boolean) {
+      const result = this.InsertCriteria?.(player) ?? null;
+      let message = result?.message ?? null;
+      if (Player.IsRestrained()) message ??= "You are restrained.";
+      if (!silent && message) sendChatLocal(message);
+      return {
+        success: message == null,
+        message: message == null ? undefined : message,
       };
     },
   },

--- a/src/core/actions/diaperSquishBack.ts
+++ b/src/core/actions/diaperSquishBack.ts
@@ -2,6 +2,7 @@ import { CombinedAction } from "../../types/types";
 import { sendDataToAction } from "../hooks";
 import { getDiaperVerb, hasDiaper } from "../player/diaper";
 import { getCharacter, isABCLPlayer, replace_template, sendABCLAction } from "../player/playerUtils";
+import { sendChatLocal } from "../utils";
 
 const diaperSquishBackRequest = (player: Character) => {
   if (player.MemberNumber !== Player.MemberNumber) return sendDataToAction("diaper-squish-back", undefined, player.MemberNumber);
@@ -12,7 +13,7 @@ export const diaperSquishBackFunction = (player: Character) => {
   const diaperVerb = getDiaperVerb(Player);
   const isSelf = player.MemberNumber === Player.MemberNumber;
   const selfMessage = `%NAME% gives %POSSESSIVE% ${diaperVerb} diapered butt a squeeze, blushing a little as it squishes under %POSSESSIVE% hand.`;
-  const otherMessage = `%OPP_NAME% gives %NAME%'s ${diaperVerb} diapered butt a teasing squeeze, smiling as %OPP_PRONOUN% squishes and kneads the ${diaperVerb} padding.`;
+  const otherMessage = `%OPP_NAME% gives %NAME%'s diapered butt a teasing squeeze, smiling as %OPP_PRONOUN% squishes and kneads the ${diaperVerb} padding.`;
   sendABCLAction(replace_template(isSelf ? selfMessage : otherMessage, player), undefined, "playerActivity", player);
 };
 
@@ -27,24 +28,23 @@ export const diaperSquishBack: CombinedAction = {
     Image: `${publicURL}/activity/diaperSquishBack.png`,
     Target: ["ItemButt"],
     OnClick: (player: Character, group: AssetGroupItemName) => diaperSquishBackRequest(player),
-    Criteria: (player: Character) => {
-      if (!isABCLPlayer(player))
-        return {
-          success: false,
-          message: "They are not an ABCL player.",
-        };
-      if (Player.IsRestrained())
-        return {
-          success: false,
-          message: "You are restrained.",
-        };
-      if (!hasDiaper(player))
-        return {
-          success: false,
-          message: "They are not diapered.",
-        };
+    InsertCriteria: function (player: Character) {
+      let message = null;
+      if (!isABCLPlayer(player)) message ??= "They are not an ABCL player.";
+      if (!hasDiaper(player)) message ??= "They are not diapered.";
       return {
-        success: true,
+        success: message == null,
+        message: message == null ? undefined : message,
+      };
+    },
+    Criteria: function (player: Character, silent?: boolean) {
+      const result = this.InsertCriteria?.(player) ?? null;
+      let message = result?.message ?? null;
+      if (Player.IsRestrained()) message ??= "You are restrained.";
+      if (!silent && message) sendChatLocal(message);
+      return {
+        success: message == null,
+        message: message == null ? undefined : message,
       };
     },
   },

--- a/src/core/actions/diaperSquishFront.ts
+++ b/src/core/actions/diaperSquishFront.ts
@@ -2,6 +2,7 @@ import { CombinedAction } from "../../types/types";
 import { sendDataToAction } from "../hooks";
 import { getDiaperVerb, hasDiaper } from "../player/diaper";
 import { getCharacter, isABCLPlayer, replace_template, sendABCLAction } from "../player/playerUtils";
+import { sendChatLocal } from "../utils";
 
 const diaperSquishFrontRequest = (player: Character) => {
   if (player.MemberNumber !== Player.MemberNumber) return sendDataToAction("diaper-squish-front", undefined, player.MemberNumber);
@@ -11,8 +12,8 @@ const diaperSquishFrontRequest = (player: Character) => {
 export const diaperSquishFrontFunction = (player: Character) => {
   const diaperVerb = getDiaperVerb(Player);
   const isSelf = player.MemberNumber === Player.MemberNumber;
-  const selfMessage = `%NAME% presses into the front of %POSSESSIVE% ${diaperVerb} diaper, blushing as %PRONOUN% squishes %POSSESSIVE% ${diaperVerb} padding.`;
-  const otherMessage = `%OPP_NAME% presses %OPP_POSSESSIVE% hand into %NAME%'s ${diaperVerb} diaper, giggling as %OPP_PRONOUN% squishes the ${diaperVerb} padding between %POSSESSIVE% legs.`;
+  const selfMessage = `%NAME% presses into the front of %POSSESSIVE% ${diaperVerb} diaper, blushing as %PRONOUN% squishes %POSSESSIVE% padding.`;
+  const otherMessage = `%OPP_NAME% presses %OPP_POSSESSIVE% hand into %NAME%'s diaper, giggling as %OPP_PRONOUN% squishes the ${diaperVerb} padding between %POSSESSIVE% legs.`;
   sendABCLAction(replace_template(isSelf ? selfMessage : otherMessage, player), undefined, "playerActivity", player);
 };
 
@@ -27,24 +28,25 @@ export const diaperSquishFront: CombinedAction = {
     Image: `${publicURL}/activity/diaperSquishFront.png`,
     Target: ["ItemVulva"],
     OnClick: (player: Character, group: AssetGroupItemName) => diaperSquishFrontRequest(player),
-    Criteria: (player: Character) => {
-      if (!isABCLPlayer(player))
-        return {
-          success: false,
-          message: "They are not an ABCL player.",
-        };
-      if (Player.IsRestrained())
-        return {
-          success: false,
-          message: "You are restrained.",
-        };
-      if (!hasDiaper(player))
-        return {
-          success: false,
-          message: "They are not diapered.",
-        };
+    InsertCriteria: function (player: Character) {
+      let message = null;
+      if (!isABCLPlayer(player)) message ??= "They are not an ABCL player.";
+      if (!hasDiaper(player)) message ??= "They are not diapered.";
       return {
-        success: true,
+        success: message == null,
+        message: message == null ? undefined : message,
+      };
+    },
+    Criteria: function (player: Character, silent?: boolean) {
+      const result = this.InsertCriteria?.(player) ?? null;
+      let message = result?.message ?? null;
+
+      if (Player.IsRestrained()) message ??= "You are restrained.";
+
+      if (!silent && message) sendChatLocal(message);
+      return {
+        success: message == null,
+        message: message == null ? undefined : message,
       };
     },
   },

--- a/src/core/actions/lickPuddle.ts
+++ b/src/core/actions/lickPuddle.ts
@@ -2,6 +2,7 @@ import { CombinedAction } from "../../types/types";
 import { sendDataToAction, sendUpdateMyData } from "../hooks";
 import { abclPlayer } from "../player/player";
 import { getCharacter, isABCLPlayer, replace_template, sendABCLAction, targetInputExtractor } from "../player/playerUtils";
+import { sendChatLocal } from "../utils";
 
 const lickPuddleRequest = (player: Character) => {
   const isSelf = player.MemberNumber === Player.MemberNumber;
@@ -30,19 +31,22 @@ export const lickPuddle: CombinedAction = {
     Image: `${publicURL}/activity/lickPuddle.png`,
     Target: ["ItemBoots"],
     OnClick: (player: Character, group: AssetGroupItemName) => lickPuddleRequest(player),
-    Criteria: (player: Character) => {
-      if (!isABCLPlayer(player))
-        return {
-          success: false,
-          message: "They are not an ABCL player.",
-        };
-      if (player.ABCL!.Stats.PuddleSize.value <= 0)
-        return {
-          success: false,
-          message: "They have no puddle of lick.",
-        };
+    InsertCriteria: function (player: Character) {
+      let message = null;
+      if (!isABCLPlayer(player)) message ??= "They are not an ABCL player.";
+      if (player?.ABCL && player.ABCL!.Stats.PuddleSize.value <= 0) message ??= "They have no puddle of pee.";
       return {
-        success: true,
+        success: message == null,
+        message: message == null ? undefined : message,
+      };
+    },
+    Criteria: function (player: Character, silent?: boolean) {
+      const result = this.InsertCriteria?.(player) ?? null;
+      let message = result?.message ?? null;
+      if (!silent && message) sendChatLocal(message);
+      return {
+        success: message == null,
+        message: message == null ? undefined : message,
       };
     },
   },

--- a/src/core/actions/makeAWish.ts
+++ b/src/core/actions/makeAWish.ts
@@ -13,7 +13,9 @@ export const makeAWish: CombinedAction = {
           "The diaper goddess can't grant a wish you haven't spoken~",
           "Use your words, baby! The diaper goddess wants to hear your wish~",
         ];
-        sendChatLocal(noWishResponses[Math.floor(Math.random() * noWishResponses.length)]);
+        const response = noWishResponses[Math.floor(Math.random() * noWishResponses.length)];
+        if (response == null) return;
+        sendChatLocal(response);
         return;
       }
 

--- a/src/core/actions/pauseStats.ts
+++ b/src/core/actions/pauseStats.ts
@@ -1,12 +1,11 @@
 import { CombinedAction } from "../../types/types";
 import { sendABCLAction } from "../player/playerUtils";
+import { sendChatLocal } from "../utils";
 
 export const pauseStatsFunction = () => {
-  if(Player.ABCL.SettingPermissions.PauseStats) {
-    const isPaused = Player.ABCL.Settings.PauseStats;
-    sendABCLAction(isPaused ? "%NAME% resumed their ABCL stats." : "%NAME% paused their ABCL stats.", Player, "pauseStats");
-    Player.ABCL.Settings.PauseStats = !isPaused;
-  }
+  const isPaused = Player.ABCL.Settings.PauseStats;
+  sendABCLAction(isPaused ? "%NAME% resumed their ABCL stats." : "%NAME% paused their ABCL stats.", Player, "pauseStats");
+  Player.ABCL.Settings.PauseStats = !isPaused;
 };
 
 export const pauseStats: CombinedAction = {
@@ -16,15 +15,30 @@ export const pauseStats: CombinedAction = {
     Image: `${publicURL}/activity/pauseStats.png`,
     TargetSelf: ["ItemPelvis"],
     OnClick: (player: Character, group: AssetGroupItemName) => pauseStatsFunction(),
-    Criteria: (player: Character) => {
+    InsertCriteria: function (player: Character) {
+      let message = null;
       return {
-        success: true,
+        success: message == null,
+        message: message == null ? undefined : message,
+      };
+    },
+    Criteria: function (player: Character, silent?: boolean) {
+      const result = this.InsertCriteria?.(player) ?? null;
+      let message = result?.message ?? null;
+      if (Player.ABCL.SettingPermissions.PauseStats) message ??= "Your parent(s) don't allow you to pause your stats";
+      if (!silent && message) sendChatLocal(message);
+      return {
+        success: message == null,
+        message: message == null ? undefined : message,
       };
     },
   },
   command: {
     Tag: "pause-stats",
-    Action: (args, msg, parsed) => pauseStatsFunction(),
+    Action: (args, msg, parsed) => {
+      if (!pauseStats.activity!.Criteria!(Player).success) return;
+      pauseStatsFunction();
+    },
     Description: ` Pauses the ABCL stats.`,
   },
 };

--- a/src/core/actions/sync.ts
+++ b/src/core/actions/sync.ts
@@ -46,7 +46,7 @@ settingsRemote.on("sync", (info, { Settings, Stats, Version, SettingPermissions 
 
   const index = ChatRoomCharacter.findIndex(character => character.MemberNumber === info.sender);
   if (index === -1) return logger.warn(`Could not find character with member number ${info.sender}`);
-
+  if (ChatRoomCharacter[index] == null) return;
   logger.debug(`Updating data for ${info.sender}`);
   ChatRoomCharacter[index].ABCL = {
     Stats,

--- a/src/core/actions/usePotty.ts
+++ b/src/core/actions/usePotty.ts
@@ -3,6 +3,7 @@ import { CombinedAction } from "../../types/types";
 import { hasDiaper, isDiaperLocked } from "../player/diaper";
 import { abclPlayer } from "../player/player";
 import { sendABCLAction } from "../player/playerUtils";
+import { sendChatLocal } from "../utils";
 
 export const usePottyFunction = () => {
   const incontinenceOffset = 0.3 * abclPlayer.stats.Incontinence;
@@ -59,14 +60,21 @@ export const usePotty: CombinedAction = {
     Image: `${publicURL}/activity/potty-temp.png`,
     OnClick: (player: Character, group) => usePottyFunction(),
     TargetSelf: ["ItemButt"],
-    Criteria: (player: Character) => {
-      if (!player.Appearance.some(item => item.Asset.Name == "Potty"))
-        return {
-          success: false,
-          message: "You don't have a potty to use!",
-        };
+    InsertCriteria: function (player: Character) {
+      let message = null;
       return {
-        success: true,
+        success: message == null,
+        message: message == null ? undefined : message,
+      };
+    },
+    Criteria: function (player: Character, silent?: boolean) {
+      const result = this.InsertCriteria?.(player) ?? null;
+      let message = result?.message ?? null;
+      if (!player.Appearance.some(item => item.Asset.Name == "Potty")) message ??= "You don't have a potty to use!";
+      if (!silent && message) sendChatLocal(message);
+      return {
+        success: message == null,
+        message: message == null ? undefined : message,
       };
     },
   },

--- a/src/core/actions/useToilet.ts
+++ b/src/core/actions/useToilet.ts
@@ -44,29 +44,26 @@ export const useToilet: CombinedAction = {
     Image: `${publicURL}/activity/toilet-temp.png`,
     OnClick: (player, group) => useToiletFunction(),
     // if the regression is too high, deny toilet usage
-    Criteria: player => {
-      if (abclPlayer.stats.MentalRegression >= 0.3)
-        return {
-          success: false,
-          message: "You feel uncomfortable, the toilet is cold and hard almost like ice. You can't use it.",
-        };
-      // when CanUseBathroomWithDiaper is false or abclPlayer.settings.CanUseToilet is false then it will deny toilet usage by wetting their clothes or diaper.
-      if (!abclPlayer.settings.CanUseBathroomWithDiaper || !abclPlayer.settings.CanUseToilet)
-        return {
-          success: true,
-        };
-      if (hasDiaper(player) && isDiaperLocked())
-        return {
-          success: false,
-          message: "You can't use the toilet while your diaper is locked.",
-        };
-      if (Player.IsRestrained())
-        return {
-          success: false,
-          message: "You are restrained.",
-        };
+    InsertCriteria: function (player: Character) {
+      let message = null;
       return {
-        success: true,
+        success: message == null,
+        message: message == null ? undefined : message,
+      };
+    },
+    Criteria: function (player: Character, silent?: boolean) {
+      const result = this.InsertCriteria?.(player) ?? null;
+      let message = result?.message ?? null;
+      if (abclPlayer.stats.MentalRegression >= 0.3) message ??= "You feel uncomfortable, the toilet is cold and hard almost like ice. You can't use it.";
+      // when CanUseBathroomWithDiaper is false or abclPlayer.settings.CanUseToilet is false then it will deny toilet usage by wetting their clothes or diaper.
+      if ((hasDiaper(player) && !abclPlayer.settings.CanUseBathroomWithDiaper) || !abclPlayer.settings.CanUseToilet) return { success: true };
+      if (hasDiaper(player) && isDiaperLocked()) message ??= "You can't use the toilet while your diaper is locked.";
+      if (Player.IsRestrained()) message ??= "You are restrained.";
+
+      if (!silent && message) sendChatLocal(message);
+      return {
+        success: message == null,
+        message: message == null ? undefined : message,
       };
     },
     TargetSelf: ["ItemButt"],

--- a/src/core/actions/wipePuddle.ts
+++ b/src/core/actions/wipePuddle.ts
@@ -1,7 +1,8 @@
 import { CombinedAction } from "../../types/types";
 import { sendDataToAction, sendUpdateMyData } from "../hooks";
 import { abclPlayer } from "../player/player";
-import { getCharacter, isABCLPlayer, replace_template, sendABCLAction } from "../player/playerUtils";
+import { getCharacter, isABCLPlayer, replace_template, sendABCLAction, targetInputExtractor } from "../player/playerUtils";
+import { sendChatLocal } from "../utils";
 const WipePuddleRequest = (player: Character) => {
   if (player.MemberNumber !== Player.MemberNumber) return sendDataToAction("wipe-puddle", undefined, player.MemberNumber);
   WipePuddleFunction(Player);
@@ -25,31 +26,30 @@ export const wipePuddle: CombinedAction = {
     Image: `./Assets/Female3DCG/ItemHandheld/Preview/Towel.png`,
     Target: ["ItemBoots"],
     OnClick: (player: Character, group: AssetGroupItemName) => WipePuddleRequest(player),
-    Criteria: (player: Character) => {
-      if (!isABCLPlayer(player))
-        return {
-          success: false,
-          message: "They are not an ABCL player.",
-        };
-      if (player.ABCL!.Stats.PuddleSize.value <= 0)
-        return {
-          success: false,
-          message: "They have no puddle.",
-        };
-      if (Player.IsRestrained())
-        return {
-          success: false,
-          message: "You are restrained.",
-        };
+    InsertCriteria: function (player: Character) {
+      let message = null;
+      if (!isABCLPlayer(player)) message ??= "They are not an ABCL player.";
+      if (player.ABCL && player.ABCL.Stats.PuddleSize.value <= 0) message ??= "They have no puddle.";
       return {
-        success: true,
+        success: message == null,
+        message: message == null ? undefined : message,
+      };
+    },
+    Criteria: function (player: Character, silent?: boolean) {
+      const result = this.InsertCriteria?.(player) ?? null;
+      let message = result?.message ?? null;
+      if (Player.IsRestrained()) message ??= "You are restrained.";
+      if (!silent && message) sendChatLocal(message);
+      return {
+        success: message == null,
+        message: message == null ? undefined : message,
       };
     },
   },
   command: {
     Tag: "wipe-puddle",
     Action: (args, msg, parsed) => {
-      const character = getCharacter(parsed[0]) ?? Player;
+      const character = targetInputExtractor(parsed) ?? Player;
       if (!wipePuddle.activity!.Criteria!(character).success) return;
 
       WipePuddleRequest(character);

--- a/src/core/minigames/distractionRush.ts
+++ b/src/core/minigames/distractionRush.ts
@@ -248,11 +248,17 @@ export class DistractionRushGame extends BaseMiniGame {
     container.innerHTML = "";
 
     const goodIndex = Math.floor(Math.random() * this.options.good.length);
-    const goodOption: { text: string; isGood: boolean } = { ...this.options.good[goodIndex], isGood: true };
-
+    const goodItem = this.options.good[goodIndex];
+    if (!goodItem) return;
+    const goodOption: { text: string; isGood: boolean } = {
+      text: goodItem.text,
+      isGood: true,
+    };
     const badCandidates: { text: string; isGood: boolean }[] = [];
     for (let i = 0; i < Math.max(Math.round(2 * MiniGameDifficulty), 1); i++) {
-      const candidate = { ...this.options.bad[Math.floor(Math.random() * this.options.bad.length)], isGood: false };
+      const bad = this.options.bad[Math.floor(Math.random() * this.options.bad.length)];
+      if (!bad) continue;
+      const candidate = { text: bad.text, isGood: false };
       badCandidates.push(candidate);
     }
 

--- a/src/core/minigames/dropletBucket/input.ts
+++ b/src/core/minigames/dropletBucket/input.ts
@@ -69,7 +69,7 @@ export class InputManager {
       return;
     }
     e.preventDefault();
-    if (e.touches.length > 0) {
+    if (e.touches.length > 0 && e.touches[0]) {
       this.game.moveBucketTo(this.getCanvasXPosition(e.touches[0].clientX));
     }
   }

--- a/src/core/minigames/dropletBucket/spawner.ts
+++ b/src/core/minigames/dropletBucket/spawner.ts
@@ -44,6 +44,7 @@ export class SpawnerManager {
 
     for (let i = pool.length - 1; i > 0; i--) {
       const j = Math.floor(Math.random() * (i + 1));
+      // @ts-expect-error
       [pool[i], pool[j]] = [pool[j], pool[i]];
     }
 
@@ -62,7 +63,7 @@ export class SpawnerManager {
       const availableBadItems = ALL_DROPLET_WEIGHTS.filter(item => BAD_DROPLET_CLASSES.includes(item.dropletClass));
 
       const chosenBad = availableBadItems[Math.floor(Math.random() * availableBadItems.length)];
-
+      if (chosenBad == null) return;
       const replaceIndex = selected.findIndex(item => item.dropletClass !== NormalDropletEntity);
 
       if (replaceIndex !== -1) {
@@ -82,6 +83,7 @@ export class SpawnerManager {
     }
 
     let randomWeight = Math.random() * this.totalActiveWeight;
+    if (this.activePool[0] == null) return;
     let SelectedClass: DropletConstructor = this.activePool[0].dropletClass;
 
     for (const item of this.activePool) {

--- a/src/core/particleSystem.ts
+++ b/src/core/particleSystem.ts
@@ -129,7 +129,10 @@ export class ParticleSystem {
   }
   addParticle(memberNumber: number, x: number, y: number, speed: number, life: number, angle: number = 0, image: string) {
     const maxAllowed = this.settings.limit * (ChatRoomCharacter?.length || 1);
-    const particles = this.playerParticles.getOrInsert(memberNumber, []);
+    if (!this.playerParticles.has(memberNumber)) {
+      this.playerParticles.set(memberNumber, []);
+    }
+    const particles = this.playerParticles.get(memberNumber)!;
     if (particles.length > maxAllowed || Math.random() > this.settings.spawnChance) {
       return;
     }

--- a/src/core/player/diaper.ts
+++ b/src/core/player/diaper.ts
@@ -36,6 +36,7 @@ export function hasDiaper(player: Character = Player): boolean {
     (pelvisItem && isDiaper(pelvisItem)) || (panties && isDiaper(panties)) || (panties2 && isDiaper(panties2)) || (suitLower && isDiaper(suitLower)),
   );
 }
+
 export const isWearingBabyClothes = () => {
   return Player.Appearance.some(clothing => {
     return ABCLdata.ItemDefinitions.BabyItems.includes(clothing.Asset.DynamicGroupName + clothing.Asset.Name);
@@ -84,7 +85,9 @@ export const setDiaperColor = (slot: AssetGroupName, primaryColor: string, playe
     const dirtiness = Math.min(abclPlayer.stats.SoilinessValue + abclPlayer.stats.WetnessValue / getPlayerDiaperSize(), 1);
     if ("indicator" in diaper) {
       for (const index of diaper.indicator) {
-        color[index] = averageColor(ABCLdata.DiaperColors.indicatorAccident, item.Asset.DefaultColor[index], dirtiness) as BCColor;
+        const defaultColor = item.Asset.DefaultColor[index];
+        if (defaultColor == null) continue;
+        color[index] = averageColor(ABCLdata.DiaperColors.indicatorAccident, defaultColor, dirtiness) as BCColor;
       }
     }
     const protection = item?.Craft?.Effects?.["DiaperDiscolorationProtection" as CraftingPropertyType] ?? 0;
@@ -202,7 +205,10 @@ export function incontinenceChanceFormula(incontinence: number, fullness: number
 
 // mental regression
 export const mentalRegressionBonus = () => {
-  const matches = Player.Appearance.filter(clothing => clothing.Asset.DynamicGroupName + clothing.Asset.Name in ABCLdata.ItemDefinitions.BabyItems);
+  const matches = Player.Appearance.filter(clothing => {
+    const key = clothing.Asset.DynamicGroupName + clothing.Asset.Name;
+    return ABCLdata.ItemDefinitions.BabyItems.includes(key);
+  });
   return Math.min(matches.length * 0.25, 1);
 };
 export const mentalRegressionOvertime = () => {
@@ -248,21 +254,18 @@ const wetnessVerbs = {
   15: "damp",
   30: "moist",
   45: "wet",
-  60: "heavy with urine",
-  75: "soggy",
-  85: "dripping wet",
-  95: "saturated and dripping",
+  60: "soggy",
+  75: "flooded",
 };
 const soilinessVerbs = {
   0: "",
   15: "slightly stained",
   30: "smudged",
   45: "soiled",
-  60: "heavy and soiled",
-  75: "full and messy",
-  85: "overflowing with mess",
-  95: "overwhelmingly full",
+  60: "messy",
+  75: "heavy",
 };
+
 export const getDiaperVerb = (player: Character) => {
   if (!hasDiaper(player)) return "";
   const size = getPlayerDiaperSize(player);
@@ -281,7 +284,7 @@ export const getDiaperVerb = (player: Character) => {
     return "dripping with moisture";
   }
   if (soilinessPercent > 90) {
-    return "distressingly full";
+    return "full";
   }
 
   if (soilinessVerb == "") {

--- a/src/core/player/player.ts
+++ b/src/core/player/player.ts
@@ -60,8 +60,7 @@ export const abclPlayer = {
   },
   /** once per minute */
   update: () => {
-    if (Player.ABCL.Settings.PauseStats)
-    {
+    if (Player.ABCL.Settings.PauseStats) {
       if (!Player.ABCL.Settings.UnPauseStatsWhenDiapered || !hasDiaper()) return;
 
       // re-enable stats if the player has a diaper on, since they can still have accidents
@@ -123,21 +122,13 @@ export const abclPlayer = {
     const panties = InventoryGet(Player, "Panties");
     if (panties && !isDiaper(panties)) {
       const pantiesColors = getColor(panties.Color || (panties.Asset.DefaultColor as ItemColor), panties.Asset);
-      for (let i = 0; i < pantiesColors.length; i++) {
-        if (!isColorable(pantiesColors[i])) continue;
-        pantiesColors[i] = averageColor(pantiesColors[i], wetColor, 0.3);
-      }
-      panties.Color = pantiesColors;
+      panties.Color = pantiesColors.map(color => (isColorable(color) ? averageColor(color, wetColor, 0.3) : color));
     }
 
     for (const item of Player.Appearance) {
       if (ABCLdata.ItemDefinitions.Pants.some(pants => pants === item.Asset.DynamicGroupName + item.Asset.Name)) {
         const colors = getColor(item.Color || (item.Asset.DefaultColor as ItemColor), item.Asset);
-        for (let i = 0; i < colors.length; i++) {
-          if (!isColorable(colors[i])) continue;
-          colors[i] = averageColor(colors[i], wetColor, 0.3);
-        }
-        item.Color = colors;
+        item.Color = colors.map(color => (isColorable(color) ? averageColor(color, wetColor, 0.3) : color));
       }
     }
 
@@ -169,21 +160,13 @@ export const abclPlayer = {
     const panties = InventoryGet(Player, "Panties");
     if (panties && !isDiaper(panties)) {
       const pantiesColors = getColor(panties.Color || (panties.Asset.DefaultColor as ItemColor), panties.Asset);
-      for (let i = 0; i < pantiesColors.length; i++) {
-        if (!isColorable(pantiesColors[i])) continue;
-        pantiesColors[i] = averageColor(pantiesColors[i], messColor, 0.3);
-      }
-      panties.Color = pantiesColors;
+      panties.Color = pantiesColors.map(color => (isColorable(color) ? averageColor(color, messColor, 0.3) : color));
     }
 
     for (const item of Player.Appearance) {
       if (ABCLdata.ItemDefinitions.Pants.some(pants => pants === item.Asset.DynamicGroupName + item.Asset.Name)) {
         const colors = getColor(item.Color || (item.Asset.DefaultColor as ItemColor), item.Asset);
-        for (let i = 0; i < colors.length; i++) {
-          if (!isColorable(colors[i])) continue;
-          colors[i] = averageColor(colors[i], messColor, 0.3);
-        }
-        item.Color = colors;
+        item.Color = colors.map(color => (isColorable(color) ? averageColor(color, messColor, 0.3) : color));
       }
     }
     queueUpdatePlayerClothes();
@@ -254,6 +237,11 @@ export const abclPlayer = {
 
     const difficulty = 1 + abclPlayer.miniGameDifficulty * Math.max(fullness, chance);
     const callback = isWet ? "WetMinigameResult" : "MessMinigameResult";
+    if (!abclPlayer.settings.UseNewMiniGame) {
+      const minigame = isWet ? "DistractionRush-Wetting" : "DistractionRush-Messes";
+      MiniGameStart(minigame as ModuleScreens["MiniGame"], difficulty, callback as any);
+      return;
+    }
     MiniGameStart("DropletCatch" as ModuleScreens["MiniGame"], difficulty, callback as any);
   },
   /** @Deprecated use `attemptAccident` instead */

--- a/src/core/player/playerUtils.ts
+++ b/src/core/player/playerUtils.ts
@@ -178,7 +178,8 @@ const statusThresholds: Record<keyof ModStats, Array<{ minPercent: number; messa
 const getZoneIndex = (percent: number, thresholds: Array<{ minPercent: number; message: string }>): number => {
   let activeIndex = -1;
   for (let i = 0; i < thresholds.length; i++) {
-    if (percent >= thresholds[i].minPercent) {
+    const { minPercent } = thresholds[i] ?? {};
+    if (minPercent && percent >= minPercent) {
       activeIndex = i;
     }
   }
@@ -200,8 +201,9 @@ export const sendStatusMessage = (type: keyof ModStats, before: number, after: n
   const afterZone = getZoneIndex(afterPercent, thresholds);
 
   if (beforeZone === afterZone || afterZone === -1) return;
-
-  const descMessage = thresholds[afterZone].message;
+  const threshold = thresholds[beforeZone];
+  if (!threshold) return;
+  const descMessage = threshold.message;
   const isLocal = Player.ABCL.Settings.StatusMessages[type];
   if (descMessage === "") return;
   const message = replace_template(descMessage, Player);
@@ -217,7 +219,6 @@ export function sendABCLAction(action: string, sender: Character | null = null, 
   let msg = replace_template(action, sender);
   const isLocal = !Player.ABCL.Settings.VisibleMessages[messageType];
   sendChatLocal(msg, ["ChatMessageAction", "ChatMessageNonDialogue"], "--label-color:#ff4949", isLocal);
-
   if (!isLocal) {
     sendDataToAction("onABCLMessage", { message: msg, local: isLocal });
   } else if (target && target.MemberNumber !== Player.MemberNumber) {

--- a/src/core/player/ui.ts
+++ b/src/core/player/ui.ts
@@ -22,8 +22,7 @@ export const resizeElements = () => {
   ElementPositionFixed("ABCL-stats-panel", 1700, 0, 300, 1000);
 
   const exitButtons = document.querySelectorAll(`.${modIdentifier}-exit-button`);
-  for (let i = 0; i < exitButtons.length; i++) {
-    const exitButton = exitButtons[i];
+  for (const exitButton of exitButtons) {
     exitButton.id = exitButton.id || generateUniqueID();
     ElementPositionFixed(exitButton.id, 1815, 75, 90, 90);
   }

--- a/src/core/settings.ts
+++ b/src/core/settings.ts
@@ -56,6 +56,7 @@ export const defaultSettings: ModSettings = {
   DisableParticles: false,
   UnPauseStatsWhenDiapered: true,
   MiniGameAudioMuted: false,
+  UseNewMiniGame: true,
 };
 
 export const defaultStats: ModStats = {
@@ -142,6 +143,7 @@ export const defaultSettingPermissions: ModStorageModel["SettingPermissions"] = 
   DisableParticles: false,
   UnPauseStatsWhenDiapered: true,
   MiniGameAudioMuted: false,
+  UseNewMiniGame: false,
 };
 
 const defaultData: ModStorageModel = {

--- a/src/screens/Settings/pages/about.tsx
+++ b/src/screens/Settings/pages/about.tsx
@@ -1,7 +1,7 @@
 import { h } from "preact";
-import "./about.css";
 import { Stack } from "src/screens/components/positionComponents";
-import styled from "@emotion/styled";
+import styled from "styled-components";
+import "./about.css";
 
 const CreditItemComponent = styled.p`
   margin: 0;

--- a/src/screens/Settings/pages/changelog.tsx
+++ b/src/screens/Settings/pages/changelog.tsx
@@ -1,7 +1,7 @@
 import { h, JSX } from "preact";
 import { useEffect, useState } from "preact/hooks";
 import { getDirectoryContents, GitHubFileItem } from "src/core/utils";
-import styled from "@emotion/styled";
+import styled from "styled-components";
 
 interface ChangelogEntry {
   title: string;

--- a/src/screens/Settings/pages/misc.tsx
+++ b/src/screens/Settings/pages/misc.tsx
@@ -59,6 +59,7 @@ export default function MiscPage({ setPage }: { setPage: (page: string) => void 
   const [puddleSize, setPuddleSize] = useState<boolean>(Player.ABCL.Settings.StatusMessages["PuddleSize"] ?? false);
 
   const [showOwnBadges, setShowOwnBadges] = useState<boolean>(Player.ABCL.Settings.ShowOwnBadges);
+  const [useNewMiniGame, setUseNewMiniGame] = useState<boolean>(Player.ABCL.Settings.UseNewMiniGame);
 
   return (
     <div>
@@ -114,6 +115,7 @@ export default function MiscPage({ setPage }: { setPage: (page: string) => void 
           Player.ABCL.SettingPermissions.CanUsePotty = canUsePottyLocked;
 
           Player.ABCL.Settings.DisableParticles = disableParticles;
+          Player.ABCL.Settings.UseNewMiniGame = useNewMiniGame;
         }}
         className="ABCL-exit-button"
       ></button>
@@ -125,6 +127,9 @@ export default function MiscPage({ setPage }: { setPage: (page: string) => void 
           </SettingPanel>
           <SettingPanel title="Disable particles">
             <Checkbox checked={disableParticles} setChecked={setDisableParticles} showLock={false} />
+          </SettingPanel>
+          <SettingPanel title="Use new Minigame (may not stay forever)">
+            <Checkbox checked={useNewMiniGame} setChecked={setUseNewMiniGame} showLock={false} />
           </SettingPanel>
         </Group>
       </div>

--- a/src/screens/Settings/pages/shared-settings.tsx
+++ b/src/screens/Settings/pages/shared-settings.tsx
@@ -36,7 +36,9 @@ export default function SharedSettingsPage({ setPage, selectedCharacter }: { set
   const [poopMetabolismLocked, setPoopMetabolismLocked] = useState<boolean>(selectedCharacter.ABCL.SettingPermissions.PoopMetabolism);
   const [mentalMetabolismLocked, setMentalMetabolismLocked] = useState<boolean>(selectedCharacter.ABCL.SettingPermissions.MentalRegressionModifier);
   const [diaperChangePromptSettingLocked, setDiaperChangePromptSettingLocked] = useState<boolean>(selectedCharacter.ABCL.SettingPermissions.OnDiaperChange);
-  const [unPauseStatsWhenDiaperedLocked, setUnPauseStatsWhenDiaperedLocked] = useState<boolean>(selectedCharacter.ABCL.SettingPermissions.UnPauseStatsWhenDiapered);
+  const [unPauseStatsWhenDiaperedLocked, setUnPauseStatsWhenDiaperedLocked] = useState<boolean>(
+    selectedCharacter.ABCL.SettingPermissions.UnPauseStatsWhenDiapered,
+  );
   const [pauseStatsLocked, setPauseStatsLocked] = useState<boolean>(selectedCharacter.ABCL.SettingPermissions.PauseStats);
   const [disableWettingLeaksLocked, setDisableWettingLeaksLocked] = useState<boolean>(selectedCharacter.ABCL.SettingPermissions.DisableWettingLeaks);
   const [disableSoilingLeaksLocked, setDisableSoilingLeaksLocked] = useState<boolean>(selectedCharacter.ABCL.SettingPermissions.DisableSoilingLeaks);
@@ -58,6 +60,7 @@ export default function SharedSettingsPage({ setPage, selectedCharacter }: { set
 
   const [canUseToiletLocked, setCanUseToiletLocked] = useState<boolean>(selectedCharacter.ABCL.SettingPermissions.CanUseToilet);
   const [canUsePottyLocked, setCanUsePottyLocked] = useState<boolean>(selectedCharacter.ABCL.SettingPermissions.CanUsePotty);
+
   return (
     <div>
       <button
@@ -119,7 +122,12 @@ export default function SharedSettingsPage({ setPage, selectedCharacter }: { set
           <Checkbox checked={pauseStats} setChecked={setPauseStats} locked={pauseStatsLocked} setLocked={setPauseStatsLocked} />
         </SettingPanel>
         <SettingPanel title="UnPause Stats When Diapered">
-          <Checkbox checked={unPauseStatsWhenDiapered} setChecked={setUnPauseStatsWhenDiapered} locked={unPauseStatsWhenDiaperedLocked} setLocked={setUnPauseStatsWhenDiaperedLocked} />
+          <Checkbox
+            checked={unPauseStatsWhenDiapered}
+            setChecked={setUnPauseStatsWhenDiapered}
+            locked={unPauseStatsWhenDiaperedLocked}
+            setLocked={setUnPauseStatsWhenDiaperedLocked}
+          />
         </SettingPanel>
         <SettingPanel title="Wetting Leaks / Puddles">
           <Checkbox

--- a/src/screens/Settings/pages/stats.tsx
+++ b/src/screens/Settings/pages/stats.tsx
@@ -1,6 +1,5 @@
 import { h } from "preact";
 
-import styled from "@emotion/styled";
 import { useState } from "preact/hooks";
 import { isOwned } from "src/core/player/diaper";
 import { clearData } from "src/core/settings";
@@ -8,6 +7,7 @@ import { MetabolismBar } from "src/screens/components/metabolismDropDown";
 import { Group, Stack } from "src/screens/components/positionComponents";
 import { SettingPanel } from "src/screens/components/settingPanel";
 import { RuleId } from "src/types/definitions";
+import styled from "styled-components";
 import { ButtonGroup } from "../../components/buttonGroup";
 import { Checkbox } from "../../components/checkbox";
 import { SettingsH2 } from "../settingsPage";
@@ -83,7 +83,12 @@ export default function StatsPage({ setPage }: { setPage: (page: string) => void
           <Checkbox checked={pauseStats} setChecked={setPauseStats} locked={pauseStatsLocked && isOwned()} opaqueLock={true} />
         </SettingPanel>
         <SettingPanel title="Resume Stats When Diapered">
-          <Checkbox checked={unPauseStatsWhenDiapered} setChecked={setUnPauseStatsWhenDiapered} locked={unPauseStatsWhenDiaperedLocked && isOwned()} opaqueLock={true} />
+          <Checkbox
+            checked={unPauseStatsWhenDiapered}
+            setChecked={setUnPauseStatsWhenDiapered}
+            locked={unPauseStatsWhenDiaperedLocked && isOwned()}
+            opaqueLock={true}
+          />
         </SettingPanel>
         <SettingPanel title="Wetting Leaks / Puddles">
           <Checkbox checked={disableWettingLeaks} setChecked={setDisableWettingLeaks} locked={disableWettingLeaksLocked && isOwned()} opaqueLock inverted />

--- a/src/screens/components/lockWidget.tsx
+++ b/src/screens/components/lockWidget.tsx
@@ -1,7 +1,7 @@
-import { JSX } from "preact/jsx-runtime";
 import { forwardRef } from "preact/compat";
-import styled from "@emotion/styled";
+import { JSX } from "preact/jsx-runtime";
 import { THEME } from "src/constants";
+import styled from "styled-components";
 
 const LockWidgetComponent = styled.div<JSX.IntrinsicElements["div"] & { noBorderLeft?: boolean; size: number }>`
   display: flex;
@@ -36,7 +36,7 @@ export const LockWidget = forwardRef<HTMLDivElement, LockWidgetProps>(({ locked,
       setLocked?.(!locked);
     }}
     noBorderLeft={noBorderLeft}
-    size={size}
+    size={size ?? 1}
   >
     {locked ? (
       <img src={`${publicURL}/icons/locked${opaque ? "-opaque" : ""}-${THEME}.svg`} alt="locked" />

--- a/src/screens/components/metabolismDropDown.tsx
+++ b/src/screens/components/metabolismDropDown.tsx
@@ -1,9 +1,9 @@
-import { JSX } from "preact/jsx-runtime";
 import { forwardRef } from "preact/compat";
-import { DropDown, BaseOptionComponent } from "./dropDown";
+import { JSX } from "preact/jsx-runtime";
 import { THEME } from "src/constants";
-import { Group } from "./positionComponents";
 import styled from "styled-components";
+import { BaseOptionComponent, DropDown } from "./dropDown";
+import { Group } from "./positionComponents";
 
 const MetabolismOptionComponent = styled(BaseOptionComponent)<{ locked?: boolean }>`
   justify-content: space-between;
@@ -60,7 +60,7 @@ export type MetabolismOption = {
 export function MetabolismOption({ value, label, icon }: MetabolismOption): JSX.Element {
   return (
     <>
-      <Group $wrap={false} $gap="0">
+      <Group wrap={false} gap="0">
         <img src={publicURL + `/icons/${icon}-metabolism-${THEME}.svg`} alt={label} />
         <span>{label}</span>
       </Group>

--- a/src/screens/components/positionComponents.tsx
+++ b/src/screens/components/positionComponents.tsx
@@ -1,16 +1,16 @@
 import { JSX } from "preact/compat";
-import styled from "@emotion/styled";
+import styled from "styled-components";
 
-export const Group = styled.div<JSX.IntrinsicElements["div"]>`
+export const Group = styled.div<{ gap?: string; wrap?: boolean } & JSX.IntrinsicElements["div"]>`
   display: flex;
   flex-direction: row;
   gap: ${props => props.gap || "0.5em"};
-  ${props => props.wrap === false || "flex-wrap: wrap;"}
+  ${props => (props.wrap !== false ? "flex-wrap: wrap;" : "")}
 `;
 
-export const Stack = styled.div<JSX.IntrinsicElements["div"]>`
-  ${props => props.wrap === false || "flex-wrap: wrap;"}
-  gap: ${props => props.gap || "0.5em"};
+export const Stack = styled.div<{ gap?: string; wrap?: boolean } & JSX.IntrinsicElements["div"]>`
   display: flex;
   flex-direction: column;
+  gap: ${props => props.gap || "0.5em"};
+  ${props => (props.wrap !== false ? "flex-wrap: wrap;" : "")}
 `;

--- a/src/screens/components/valueBar.tsx
+++ b/src/screens/components/valueBar.tsx
@@ -1,7 +1,13 @@
-import styled from "@emotion/styled";
 import { h, JSX } from "preact";
+import styled from "styled-components";
 
-const ValueBarContainer = styled.div<JSX.IntrinsicElements["div"]>`
+type ValueBarProps = {
+  color: string;
+  value: number;
+  altBar: number;
+  limit: number;
+};
+const ValueBarContainer = styled.div<JSX.IntrinsicElements["div"] & ValueBarProps>`
   background-color: rgb(255, 255, 255);
   padding: 0.5em;
   display: flex;
@@ -54,11 +60,13 @@ const ValueBarContainer = styled.div<JSX.IntrinsicElements["div"]>`
 export function ValueBar({ value, label, color, stripedSection }: { value: number; label: string; color?: string; stripedSection?: number }): h.JSX.Element {
   let alternative = 0;
   let bar = value;
-  const max = 1 - (stripedSection ?? 0);
+  if (stripedSection === undefined) stripedSection = 0;
+  const max = 1 - stripedSection;
   if (bar > max) {
     alternative = value - max;
     bar = max;
   }
+  if (color === undefined) color = "#000000";
   return (
     <ValueBarContainer color={color} limit={stripedSection} value={bar} altBar={alternative}>
       <p>{label}</p>

--- a/src/screens/styles/minigame.css
+++ b/src/screens/styles/minigame.css
@@ -33,6 +33,11 @@
   align-items: center;
   gap: 1em;
 }
+
+.abcl-minigame-vertical-list .abcl-distraction-rush-button {
+  max-width: 11em;
+  font-size: 0.7em;
+}
 /** Distraction rush */
 .abcl-distraction-rush-button {
   padding: 0.5em;

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -67,6 +67,7 @@ interface ModSettings {
   UnPauseStatsWhenDiapered: boolean;
 
   MiniGameAudioMuted: boolean;
+  UseNewMiniGame: boolean;
 }
 interface ModStats {
   PuddleSize: {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -114,6 +114,7 @@ export type ABCLActivity = {
   Target?: AssetGroupItemName[];
   TargetSelf?: AssetGroupItemName[];
   Criteria?: (player: Character, silent?: boolean) => { success: boolean; message?: string };
+  InsertCriteria?: (player: Character, silent?: boolean) => { success: boolean; message?: string };
 };
 
 export type HookListener<T> = (raw: PluginServerChatRoomMessage, data: T) => void;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmit": true,
     "skipLibCheck": true,
     "noImplicitReturns": true,
+    "noUncheckedIndexedAccess": true,
     "noUnusedLocals": true,
     "esModuleInterop": true,
     "resolveJsonModule": true,


### PR DESCRIPTION
## Changelog
Added an option to switch back to the old minigame
Adjusted the diaper verbs to be more appropriate
Fixed not being able to change yourself (if you a big girl)
Fixed an issue where everyone was stuck at 80% regression~

## Description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a setting to switch between the new and legacy distraction minigames.
  * Added clearer local feedback when actions cannot be performed.
* **Bug Fixes**
  * Improved validation for diaper, potty, toilet, puddle, and stats-related actions.
  * Fixed incorrect puddle messaging and improved action revalidation before execution.
  * Addressed a regression affecting player progression percentages.
* **Style**
  * Updated diaper-related wording for clearer, more natural descriptions.
  * Improved distraction minigame button sizing and layout.
* **Documentation**
  * Added changelog entries covering these updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->