### PR TITLE
Fixed minigames being annoying and syncing not working

### DIFF
--- a/src/assets/activities.csv
+++ b/src/assets/activities.csv
@@ -1,0 +1,159 @@
+ChatSelf-ItemButt-Caress,SourceCharacter caresses PronounPossessive SourceCharacterButt.
+ChatSelf-ItemButt-Grope,SourceCharacter gropes PronounPossessive SourceCharacterButt.
+ChatSelf-ItemButt-Inject,SourceCharacter injects PronounPossessive SourceCharacterButt.
+ChatSelf-ItemButt-MassageHands,SourceCharacter massages PronounPossessive SourceCharacterButt.
+ChatSelf-ItemButt-MasturbateFist,SourceCharacter fists and masturbates PronounPossessive SourceCharacterAss.
+ChatSelf-ItemButt-MasturbateHand,SourceCharacter fingers and masturbates PronounPossessive SourceCharacterAss.
+ChatSelf-ItemButt-MasturbateItem,SourceCharacter masturbates PronounPossessive SourceCharacterButt with PronounPossessive ActivityAsset.
+ChatSelf-ItemButt-PourItem,SourceCharacter pours ActivityAsset onto PronounPossessive SourceCharacterButt.
+ChatSelf-ItemButt-RollItem,SourceCharacter rolls a ActivityAsset over PronounPossessive SourceCharacterButt.
+ChatSelf-ItemButt-RubItem,SourceCharacter rubs PronounPossessive SourceCharacterButt with PronounPossessive ActivityAsset.
+ChatSelf-ItemButt-Scratch,SourceCharacter scratches PronounPossessive SourceCharacterButt.
+ChatSelf-ItemButt-ShockItem,SourceCharacter shocks PronounPossessive SourceCharacterButt with PronounPossessive ActivityAsset.
+ChatSelf-ItemButt-Spank,SourceCharacter spanks PronounPossessive SourceCharacterButt.
+ChatSelf-ItemButt-SpankItem,SourceCharacter hits PronounPossessive SourceCharacterButt with PronounPossessive ActivityAsset.
+ChatSelf-ItemButt-TickleItem,SourceCharacter tickles PronounPossessive SourceCharacterButt with PronounPossessive ActivityAsset.
+ChatSelf-ItemButt-Wiggle,SourceCharacter wiggles PronounPossessive SourceCharacterButt.
+ChatOther-ItemButt-Bite,SourceCharacter bites TargetCharacter's TargetCharacterButt.
+ChatOther-ItemButt-Caress,SourceCharacter caresses TargetCharacter's TargetCharacterButt.
+ChatOther-ItemButt-GaggedKiss,SourceCharacter rubs PronounPossessive gag on TargetCharacter's TargetCharacterButt.
+ChatOther-ItemButt-Grope,SourceCharacter gropes TargetCharacter's TargetCharacterButt.
+ChatOther-ItemButt-Inject,SourceCharacter injects TargetCharacter's TargetCharacterButt.
+ChatOther-ItemButt-Kick,SourceCharacter kicks TargetCharacter's TargetCharacterButt.
+ChatOther-ItemButt-Kiss,SourceCharacter kisses TargetCharacter's TargetCharacterButt.
+ChatOther-ItemButt-MassageHands,SourceCharacter massages TargetCharacter's TargetCharacterButt.
+ChatOther-ItemButt-MasturbateFist,SourceCharacter uses PronounPossessive fist to masturbate TargetCharacter's TargetCharacterAss.
+ChatOther-ItemButt-MasturbateHand,SourceCharacter uses PronounPossessive fingers to masturbate TargetCharacter's TargetCharacterAss.
+ChatOther-ItemButt-MasturbateItem,SourceCharacter masturbates TargetCharacter's TargetCharacterButt with PronounPossessive ActivityAsset.
+ChatOther-ItemButt-MasturbateTongue,SourceCharacter uses PronounPossessive tongue to masturbate TargetCharacter's TargetCharacterAss.
+ChatOther-ItemButt-PenetrateFast,SourceCharacter roughly penetrates TargetCharacter's TargetCharacterButt with PronounPossessive ActivityAsset.
+ChatOther-ItemButt-PenetrateSlow,SourceCharacter slowly penetrates TargetCharacter's TargetCharacterButt with PronounPossessive ActivityAsset.
+ChatOther-ItemButt-PourItem,SourceCharacter pours ActivityAsset onto TargetCharacter's TargetCharacterButt.
+ChatOther-ItemButt-RollItem,SourceCharacter rolls a ActivityAsset over TargetCharacter's TargetCharacterButt.
+ChatOther-ItemButt-RubItem,SourceCharacter rubs TargetCharacter's TargetCharacterButt with PronounPossessive ActivityAsset.
+ChatOther-ItemButt-Scratch,SourceCharacter scratches over TargetCharacter's TargetCharacterButt.
+ChatOther-ItemButt-ShockItem,SourceCharacter shocks TargetCharacter's TargetCharacterButt with PronounPossessive ActivityAsset.
+ChatOther-ItemButt-Spank,SourceCharacter spanks TargetCharacter's TargetCharacterButt.
+ChatOther-ItemButt-SpankItem,SourceCharacter hits TargetCharacter's TargetCharacterButt with PronounPossessive ActivityAsset.
+ChatOther-ItemButt-Step,SourceCharacter presses PronounPossessive foot into TargetCharacter's TargetCharacterButt.
+ChatOther-ItemButt-TickleItem,SourceCharacter tickles TargetCharacter's TargetCharacterButt with PronounPossessive ActivityAsset.
+
+ChatOther-ItemVulva-ReversePenetrateAss,SourceCharacter fucks TargetCharacter's ActivityAsset with PronounPossessive TargetCharacterAss.
+ChatOther-ItemVulva-Caress,SourceCharacter caresses TargetCharacter's TargetCharacterPussy with PronounPossessive fingers.
+//ChatOther-ItemVulva-DeepThroat,SourceCharacter deepthroats TargetCharacter's ActivityAsset.
+ChatOther-ItemVulva-ReversePenetratePussy,SourceCharacter fucks TargetCharacter's ActivityAsset with PronounPossessive TargetCharacterPussy.
+ChatOther-ItemVulva-GaggedKiss,SourceCharacter pushes PronounPossessive gag into TargetCharacter's TargetCharacterPussy.
+ChatOther-ItemVulva-Kick,SourceCharacter kicks TargetCharacter on TargetPronounPossessive TargetCharacterPussy.
+ChatOther-ItemVulva-Kiss,SourceCharacter kisses TargetCharacter's TargetCharacterPussy.
+ChatOther-ItemVulva-Lick,SourceCharacter licks TargetCharacter's TargetCharacterPussy.
+ChatOther-ItemVulva-MasturbateFist,SourceCharacter masturbates TargetCharacter's TargetCharacterPussy with PronounPossessive full fist.
+ChatOther-ItemVulva-MasturbateFoot,SourceCharacter masturbates TargetCharacter's TargetCharacterPussy with PronounPossessive foot.
+ChatOther-ItemVulva-MasturbateHand,SourceCharacter masturbates TargetCharacter's TargetCharacterPussy with PronounPossessive fingers.
+ChatOther-ItemVulva-MasturbateItem,SourceCharacter uses PronounPossessive ActivityAsset to masturbate TargetCharacter's TargetCharacterPussy.
+ChatOther-ItemVulva-MasturbateTongue,SourceCharacter masturbates TargetCharacter's TargetCharacterPussy with PronounPossessive tongue.
+ChatOther-ItemVulva-Nibble,SourceCharacter nibbles TargetCharacter's TargetCharacterPussy.
+ChatOther-ItemVulva-PenetrateFast,SourceCharacter roughly penetrates TargetCharacter's TargetCharacterPussy with PronounPossessive ActivityAsset.
+ChatOther-ItemVulva-PenetrateSlow,SourceCharacter slowly penetrates TargetCharacter's TargetCharacterPussy with PronounPossessive ActivityAsset.
+ChatOther-ItemVulva-RubItem,SourceCharacter rubs TargetCharacter's TargetCharacterPussy with PronounPossessive ActivityAsset.
+ChatOther-ItemVulva-Scratch,SourceCharacter scratches over TargetCharacter's TargetCharacterPussy.
+ChatOther-ItemVulva-ShockItem,SourceCharacter shocks TargetCharacter's TargetCharacterPussy with PronounPossessive ActivityAsset.
+ChatOther-ItemVulva-Slap,SourceCharacter slaps TargetCharacter's TargetCharacterPussy.
+ChatOther-ItemVulva-SpankItem,SourceCharacter hits TargetCharacter's TargetCharacterPussy with PronounPossessive ActivityAsset.
+ChatOther-ItemVulva-SuckPenetrateItem,SourceCharacter sucks on TargetCharacter's ActivityAsset.
+ChatOther-ItemVulva-ReverseSuckItem,SourceCharacter eagerly sucks TargetCharacter's ActivityAsset.
+ChatOther-ItemVulva-TickleItem,SourceCharacter tickles TargetCharacter's TargetCharacterPussy with PronounPossessive ActivityAsset.
+
+ChatSelf-ItemVulva-Caress,SourceCharacter caresses PronounPossessive SourceCharacterPussy.
+ChatSelf-ItemVulva-MasturbateFist,SourceCharacter fists and masturbates PronounPossessive SourceCharacterPussy.
+ChatSelf-ItemVulva-MasturbateHand,SourceCharacter masturbates PronounPossessive SourceCharacterPussy.
+ChatSelf-ItemVulva-MasturbateItem,SourceCharacter masturbates PronounPossessive own SourceCharacterPussy with PronounPossessive ActivityAsset.
+ChatSelf-ItemVulva-RubItem,SourceCharacter rubs PronounPossessive own SourceCharacterPussy with PronounPossessive ActivityAsset.
+ChatSelf-ItemVulva-Scratch,SourceCharacter scratches PronounPossessive SourceCharacterPussy.
+ChatSelf-ItemVulva-ShockItem,SourceCharacter shocks PronounPossessive own SourceCharacterPussy with PronounPossessive ActivityAsset.
+ChatSelf-ItemVulva-Slap,SourceCharacter slaps PronounPossessive SourceCharacterPussy.
+ChatSelf-ItemVulva-SpankItem,SourceCharacter hits PronounPossessive SourceCharacterPussy with PronounPossessive ActivityAsset.
+ChatSelf-ItemVulva-TickleItem,SourceCharacter tickles PronounPossessive own SourceCharacterPussy with PronounPossessive ActivityAsset.
+ChatSelf-ItemVulvaPiercings-Caress,SourceCharacter caresses PronounPossessive SourceCharacterClitoris.
+ChatSelf-ItemVulvaPiercings-Inject,SourceCharacter injects PronounPossessive SourceCharacterClitoris.
+ChatSelf-ItemVulvaPiercings-MasturbateHand,SourceCharacter masturbates PronounPossessive SourceCharacterClitoris.
+ChatSelf-ItemVulvaPiercings-MasturbateItem,SourceCharacter masturbates PronounPossessive own SourceCharacterClitoris with PronounPossessive ActivityAsset.
+ChatSelf-ItemVulvaPiercings-RubItem,SourceCharacter rubs PronounPossessive own SourceCharacterClitoris with PronounPossessive ActivityAsset.
+ChatSelf-ItemVulvaPiercings-ShockItem,SourceCharacter shocks PronounPossessive own SourceCharacterClitoris with PronounPossessive ActivityAsset.
+ChatSelf-ItemVulvaPiercings-Slap,SourceCharacter slaps PronounPossessive SourceCharacterClitoris.
+ChatSelf-ItemVulvaPiercings-SpankItem,SourceCharacter hits PronounPossessive SourceCharacterClitoris with PronounPossessive ActivityAsset.
+ChatSelf-ItemVulvaPiercings-TickleItem,SourceCharacter tickles PronounPossessive own SourceCharacterClitoris with PronounPossessive ActivityAsset.
+
+ChatOther-ItemVulvaPiercings-Caress,SourceCharacter caresses TargetCharacter's TargetCharacterClitoris with PronounPossessive fingers.
+ChatOther-ItemVulvaPiercings-GaggedKiss,SourceCharacter gags kiss TargetCharacter's TargetCharacterClitoris.
+ChatOther-ItemVulvaPiercings-Inject,SourceCharacter injects TargetCharacter's TargetCharacterClitoris.
+ChatOther-ItemVulvaPiercings-Kick,SourceCharacter kicks TargetCharacter on TargetPronounPossessive TargetCharacterClitoris.
+ChatOther-ItemVulvaPiercings-Kiss,SourceCharacter kisses TargetCharacter's TargetCharacterClitoris.
+ChatOther-ItemVulvaPiercings-Lick,SourceCharacter licks TargetCharacter's TargetCharacterClitoris.
+ChatOther-ItemVulvaPiercings-MasturbateFoot,SourceCharacter masturbates TargetCharacter's TargetCharacterClitoris with PronounPossessive foot.
+ChatOther-ItemVulvaPiercings-MasturbateHand,SourceCharacter masturbates TargetCharacter's TargetCharacterClitoris with PronounPossessive fingers.
+ChatOther-ItemVulvaPiercings-MasturbateItem,SourceCharacter uses PronounPossessive ActivityAsset to masturbate TargetCharacter's TargetCharacterClitoris.
+ChatOther-ItemVulvaPiercings-MasturbateTongue,SourceCharacter masturbates TargetCharacter's TargetCharacterClitoris with PronounPossessive tongue.
+ChatOther-ItemVulvaPiercings-Nibble,SourceCharacter nibbles TargetCharacter's TargetCharacterClitoris.
+ChatOther-ItemVulvaPiercings-RubItem,SourceCharacter rubs TargetCharacter's TargetCharacterClitoris with PronounPossessive ActivityAsset.
+ChatOther-ItemVulvaPiercings-ShockItem,SourceCharacter shocks TargetCharacter's TargetCharacterClitoris with PronounPossessive ActivityAsset.
+ChatOther-ItemVulvaPiercings-Slap,SourceCharacter slaps TargetCharacter's TargetCharacterClitoris.
+ChatOther-ItemVulvaPiercings-SpankItem,SourceCharacter hits TargetCharacter's TargetCharacterClitoris with PronounPossessive ActivityAsset.
+ChatOther-ItemVulvaPiercings-TickleItem,SourceCharacter tickles TargetCharacter's TargetCharacterClitoris with PronounPossessive ActivityAsset.
+
+ChatSelf-ItemGlans-Caress,SourceCharacter caresses PronounPossessive SourceCharacterGlands.
+ChatSelf-ItemGlans-Inject,SourceCharacter injects PronounPossessive SourceCharacterGlands.
+ChatSelf-ItemGlans-MasturbateHand,SourceCharacter masturbates PronounPossessive SourceCharacterGlands.
+ChatSelf-ItemGlans-MasturbateItem,SourceCharacter masturbates PronounPossessive own SourceCharacterGlands with PronounPossessive ActivityAsset.
+ChatSelf-ItemGlans-RubItem,SourceCharacter rubs PronounPossessive own SourceCharacterGlands with PronounPossessive ActivityAsset.
+ChatSelf-ItemGlans-ShockItem,SourceCharacter shocks PronounPossessive own SourceCharacterGlands with PronounPossessive ActivityAsset.
+ChatSelf-ItemGlans-Slap,SourceCharacter slaps PronounPossessive SourceCharacterGlands.
+ChatSelf-ItemGlans-SpankItem,SourceCharacter hits PronounPossessive SourceCharacterGlands with PronounPossessive ActivityAsset.
+ChatSelf-ItemGlans-TickleItem,SourceCharacter tickles PronounPossessive own SourceCharacterGlands with PronounPossessive ActivityAsset.
+
+ChatOther-ItemGlans-Caress,SourceCharacter caresses TargetCharacter's TargetCharacterGlands with PronounPossessive fingers.
+ChatOther-ItemGlans-GaggedKiss,SourceCharacter gags kiss TargetCharacter's TargetCharacterGlands.
+ChatOther-ItemGlans-Inject,SourceCharacter injects TargetCharacter's TargetCharacterGlands.
+ChatOther-ItemGlans-Kick,SourceCharacter kicks TargetCharacter on TargetPronounPossessive TargetCharacterGlands.
+ChatOther-ItemGlans-Kiss,SourceCharacter kisses TargetCharacter's TargetCharacterGlands.
+ChatOther-ItemGlans-Lick,SourceCharacter licks TargetCharacter's TargetCharacterGlands.
+ChatOther-ItemGlans-MasturbateFoot,SourceCharacter masturbates TargetCharacter's TargetCharacterGlands with PronounPossessive foot.
+ChatOther-ItemGlans-MasturbateHand,SourceCharacter masturbates TargetCharacter's TargetCharacterGlands with PronounPossessive fingers.
+ChatOther-ItemGlans-MasturbateItem,SourceCharacter uses PronounPossessive ActivityAsset to masturbate TargetCharacter's TargetCharacterGlands.
+ChatOther-ItemGlans-MasturbateTongue,SourceCharacter masturbates TargetCharacter's TargetCharacterGlands with PronounPossessive tongue.
+ChatOther-ItemGlans-Nibble,SourceCharacter nibbles TargetCharacter's TargetCharacterGlands.
+ChatOther-ItemGlans-RubItem,SourceCharacter rubs TargetCharacter's TargetCharacterGlands with PronounPossessive ActivityAsset.
+ChatOther-ItemGlans-ShockItem,SourceCharacter shocks TargetCharacter's TargetCharacterGlands with PronounPossessive ActivityAsset.
+ChatOther-ItemGlans-Slap,SourceCharacter slaps TargetCharacter's TargetCharacterGlands.
+ChatOther-ItemGlans-SpankItem,SourceCharacter hits TargetCharacter's TargetCharacterGlands with PronounPossessive ActivityAsset.
+ChatOther-ItemGlans-TickleItem,SourceCharacter tickles TargetCharacter's TargetCharacterGlands with PronounPossessive ActivityAsset.
+
+ChatOther-ItemPenis-ReversePenetrateAss,SourceCharacter fucks TargetCharacter's ActivityAsset with PronounPossessive TargetCharacterAss.
+ChatOther-ItemPenis-Caress,SourceCharacter caresses TargetCharacter's TargetCharacterPenis with PronounPossessive fingers.
+ChatOther-ItemPenis-ReversePenetratePussy,SourceCharacter fucks TargetCharacter's ActivityAsset with PronounPossessive TargetCharacterPenis.
+ChatOther-ItemPenis-GaggedKiss,SourceCharacter presses PronounPossessive gag into TargetCharacter's TargetCharacterPenis.
+ChatOther-ItemPenis-Kick,SourceCharacter kicks TargetCharacter on TargetPronounPossessive TargetCharacterPenis.
+ChatOther-ItemPenis-Kiss,SourceCharacter kisses TargetCharacter's TargetCharacterPenis.
+ChatOther-ItemPenis-Lick,SourceCharacter licks TargetCharacter's TargetCharacterPenis.
+ChatOther-ItemPenis-MasturbateFoot,SourceCharacter masturbates TargetCharacter's TargetCharacterPenis with PronounPossessive foot.
+ChatOther-ItemPenis-MasturbateHand,SourceCharacter masturbates TargetCharacter's TargetCharacterPenis with PronounPossessive fingers.
+ChatOther-ItemPenis-MasturbateItem,SourceCharacter uses PronounPossessive ActivityAsset to masturbate TargetCharacter's TargetCharacterPenis.
+ChatOther-ItemPenis-MasturbateTongue,SourceCharacter masturbates TargetCharacter's TargetCharacterPenis with PronounPossessive tongue.
+ChatOther-ItemPenis-Nibble,SourceCharacter nibbles TargetCharacter's TargetCharacterPenis.
+ChatOther-ItemPenis-RubItem,SourceCharacter rubs TargetCharacter's TargetCharacterPenis with PronounPossessive ActivityAsset.
+ChatOther-ItemPenis-ShockItem,SourceCharacter shocks TargetCharacter's TargetCharacterPenis with PronounPossessive ActivityAsset.
+ChatOther-ItemPenis-Slap,SourceCharacter slaps TargetCharacter's TargetCharacterPenis.
+ChatOther-ItemPenis-SpankItem,SourceCharacter hits TargetCharacter's TargetCharacterPenis with PronounPossessive ActivityAsset.
+ChatOther-ItemPenis-ReverseSuckItem,SourceCharacter eagerly sucks TargetCharacter's ActivityAsset.
+ChatOther-ItemPenis-TickleItem,SourceCharacter tickles TargetCharacter's TargetCharacterPenis with PronounPossessive ActivityAsset.
+ChatOther-ItemPenis-SuckPenetrateItem,SourceCharacter sucks on TargetCharacter's ActivityAsset.
+ChatOther-ItemPenis-DeepThroat,SourceCharacter deep throats TargetCharacter's ActivityAsset.
+
+ChatSelf-ItemPenis-Caress,SourceCharacter caresses PronounPossessive SourceCharacterPenis.
+ChatSelf-ItemPenis-MasturbateFist,SourceCharacter fists and masturbates PronounPossessive SourceCharacterPenis.
+ChatSelf-ItemPenis-MasturbateHand,SourceCharacter masturbates PronounPossessive SourceCharacterPenis.
+ChatSelf-ItemPenis-MasturbateItem,SourceCharacter masturbates PronounPossessive SourceCharacterPenis with PronounPossessive ActivityAsset.
+ChatSelf-ItemPenis-RubItem,SourceCharacter rubs PronounPossessive SourceCharacterPenis with PronounPossessive ActivityAsset.
+ChatSelf-ItemPenis-ShockItem,SourceCharacter shocks PronounPossessive SourceCharacterPenis with PronounPossessive ActivityAsset.
+ChatSelf-ItemPenis-Slap,SourceCharacter slaps PronounPossessive SourceCharacterPenis.
+ChatSelf-ItemPenis-SpankItem,SourceCharacter hits PronounPossessive SourceCharacterPenis with PronounPossessive ActivityAsset.
+ChatSelf-ItemPenis-TickleItem,SourceCharacter tickles PronounPossessive SourceCharacterPenis with PronounPossessive ActivityAsset.

--- a/src/changelog/2.4.1.txt
+++ b/src/changelog/2.4.1.txt
@@ -1,0 +1,5 @@
+Adjusted some activities to consider if the character is wearing a diaper
+Made minigames less popup-like by giving you the option to ignore them
+Added a 5 second warm up timer for the new minigame
+Fixed syncing being very problematic
+Added ABCL introduction for new users

--- a/src/changelog/2.4.1.txt
+++ b/src/changelog/2.4.1.txt
@@ -1,5 +1,5 @@
 Adjusted some activities to consider if the character is wearing a diaper
 Made minigames less popup-like by giving you the option to ignore them
-Added a 5 second warm up timer for the new minigame
+Added a 5 second warm-up timer for the new minigame
 Fixed syncing being very problematic
 Added ABCL introduction for new users

--- a/src/core/actions/changeDiaper.ts
+++ b/src/core/actions/changeDiaper.ts
@@ -67,7 +67,7 @@ export const changeDiaper: CombinedAction = {
 
       const item = InventoryGet(player, "ItemDevices");
       if (item?.Asset.Name != "ChangingTable" && Player.IsRestrained()) message ??= "You are restrained.";
-      if (!(item && ["Crib", "MedicalBed", "ChangingTable", "Bed", "床左边", "床右边"].includes(item.Asset.Name)))
+      if (!(item && ["Crib", "BondageBench", "MedicalBed", "ChangingTable", "Bed", "床左边", "床右边"].includes(item.Asset.Name)))
         message ??= "They are not on a changing table or a flat surface.";
       if (!silent && message) sendChatLocal(message);
       return {
@@ -96,6 +96,7 @@ export const changeDiaper: CombinedAction = {
         case DiaperSettingValues.Ask:
           ToastManager.custom(`${getCharacterName(Sender)} wants to change your diaper.`, "info", {
             duration: 10 * 1000,
+            onClick: (_, toast) => {},
             onClose: (toast, reason) => {
               if (reason === "click") toast.setAttribute("aria-checked", "true");
               if (toast.getAttribute("aria-checked") !== "true") sendDataToAction("changeDiaper-rejected", undefined, Sender);

--- a/src/core/actions/diaperPour.ts
+++ b/src/core/actions/diaperPour.ts
@@ -1,6 +1,6 @@
 import { CombinedAction } from "../../types/types";
 import { sendDataToAction } from "../hooks";
-import { hasDiaper } from "../player/diaper";
+import { hasDiaper, updateDiaperColor } from "../player/diaper";
 import { abclPlayer } from "../player/player";
 import { getCharacter, isABCLPlayer, replace_template, sendABCLAction } from "../player/playerUtils";
 import { sendChatLocal } from "../utils";
@@ -16,6 +16,7 @@ export const diaperPourFunction = (player: Character) => {
   const otherMessage = "%OPP_NAME% pours water in %NAME%'s diaper.";
   sendABCLAction(replace_template(isSelf ? selfMessage : otherMessage, player), undefined, "playerActivity", player);
   abclPlayer.stats.WetnessValue += 500;
+  updateDiaperColor(true);
   if (Player.ABCL.Settings.ExpressionsByActivities) {
     CharacterSetFacialExpression(Player, "Blush", "Low", 8);
     CharacterSetFacialExpression(Player, "Eyebrows", "Soft", 8);

--- a/src/core/actions/lickPuddle.ts
+++ b/src/core/actions/lickPuddle.ts
@@ -2,7 +2,6 @@ import { CombinedAction } from "../../types/types";
 import { sendDataToAction } from "../hooks";
 import { abclPlayer } from "../player/player";
 import { getCharacter, isABCLPlayer, replace_template, sendABCLAction, targetInputExtractor } from "../player/playerUtils";
-import { syncData } from "../settings";
 import { sendChatLocal } from "../utils";
 
 const lickPuddleRequest = (player: Character) => {
@@ -19,7 +18,6 @@ const LickPuddleFunction = (player: Character) => {
     CharacterSetFacialExpression(Player, "Fluids", "DroolLow", 20);
   }
   abclPlayer.stats.PuddleSize -= 50;
-  syncData();
 };
 export type lickPuddleListeners = {
   "lick-puddle": undefined;

--- a/src/core/actions/useToilet.ts
+++ b/src/core/actions/useToilet.ts
@@ -3,7 +3,6 @@ import { CombinedAction } from "../../types/types";
 import { hasDiaper, isDiaperLocked } from "../player/diaper";
 import { abclPlayer } from "../player/player";
 import { sendABCLAction } from "../player/playerUtils";
-import { syncData } from "../settings";
 import { sendChatLocal } from "../utils";
 
 export const useToiletFunction = () => {
@@ -36,7 +35,6 @@ export const useToiletFunction = () => {
     actionMessage = `%NAME% sits down and uses the toilet ${additionalText}.`;
   }
   sendABCLAction(actionMessage, undefined, "useToilet");
-  syncData();
 };
 
 export const useToilet: CombinedAction = {

--- a/src/core/hooks.ts
+++ b/src/core/hooks.ts
@@ -261,19 +261,19 @@ const initHooks = async () => {
 
     result.substitutions.push([
       "TargetCharacterGlands",
-      hasDiaper(character) ? `glands through PronounPossessive ${sourceDiaperVerb} diaper` : "glands",
+      hasDiaper(character) ? `glands through PronounPossessive ${targetDiaperVerb} diaper` : "glands",
     ] satisfies CommonSubtituteSubstitution);
     result.substitutions.push([
       "TargetCharacterPussy",
-      hasDiaper(character) ? `pussy through PronounPossessive ${sourceDiaperVerb} diaper` : "vulva",
+      hasDiaper(character) ? `pussy through PronounPossessive ${targetDiaperVerb} diaper` : "vulva",
     ] satisfies CommonSubtituteSubstitution);
     result.substitutions.push([
       "TargetCharacterPenis",
-      hasDiaper(character) ? `penis through PronounPossessive ${sourceDiaperVerb} diaper` : "penis",
+      hasDiaper(character) ? `penis through PronounPossessive ${targetDiaperVerb} diaper` : "penis",
     ] satisfies CommonSubtituteSubstitution);
     result.substitutions.push([
       "TargetCharacterClitoris",
-      hasDiaper(character) ? `clitoris through PronounPossessive ${sourceDiaperVerb} diaper` : "clitoris",
+      hasDiaper(character) ? `clitoris through PronounPossessive ${targetDiaperVerb} diaper` : "clitoris",
     ] satisfies CommonSubtituteSubstitution);
     result.substitutions.push(["TargetCharacterButt", hasDiaper(character) ? `${targetDiaperVerb} diaper` : "butt"] satisfies CommonSubtituteSubstitution);
     result.substitutions.push([

--- a/src/core/hooks.ts
+++ b/src/core/hooks.ts
@@ -7,7 +7,7 @@ import { HookListener, ListenerTypeMap, PluginServerChatRoomMessage } from "../t
 import { actions } from "./actionLoader";
 import { settingsRemote } from "./actions/sync";
 import { logger } from "./logger";
-import { getPlayerDiaperSize, hasDiaper, isLeaking } from "./player/diaper";
+import { getDiaperVerb, getPlayerDiaperSize, hasDiaper, isLeaking } from "./player/diaper";
 import { abclPlayer } from "./player/player";
 import { isABCLPlayer } from "./player/playerUtils";
 import { resizeElements } from "./player/ui";
@@ -97,8 +97,18 @@ const receivePacket = (receivedMessage: PluginServerChatRoomMessage) => {
  * Initializes hooks for intercepting chat room messages and synchronizing player data.
  * This function waits until the server is connected before setting up hooks.
  */
-
+const activityReplacements: Record<string, string> = {};
 const initHooks = async () => {
+  CommonFetch(publicURL + "/activities.csv").then(async response => {
+    if (response.status !== 200) return;
+    const text = await response.text();
+    const parsed = CommonParseCSV(text);
+    parsed.forEach(row => {
+      if (!row[0] || !row[1]) return;
+      activityReplacements[row[0]] = row[1];
+    });
+  });
+
   await waitFor(() => ServerSocket && ServerIsConnected);
   HookManager.hookFunction("TextPrefetchFile", 1, (args, next) => {
     if (args[0] !== "Screens/Room/Crafting/Text_Crafting.csv") {
@@ -215,6 +225,64 @@ const initHooks = async () => {
     }
     return result;
   });
+  HookManager.hookFunction("ActivityDictionaryText", 1, (args, next) => {
+    const [key] = args;
+    const string = activityReplacements[key];
+    if (string == null) return next(args);
+    return string;
+  });
+  HookManager.hookFunction("ChatRoomMessageRunExtractors", 1, (args, next) => {
+    const result = next(args);
+    const [message, character] = args;
+    if (result.substitutions == null) return result;
+    const sourceDiaperVerb = getDiaperVerb(Player);
+    const targetDiaperVerb = getDiaperVerb(character);
+    result.substitutions.push([
+      "SourceCharacterGlands",
+      hasDiaper(Player) ? `glands through PronounPossessive ${sourceDiaperVerb} diaper` : "glands",
+    ] satisfies CommonSubtituteSubstitution);
+    result.substitutions.push([
+      "SourceCharacterPussy",
+      hasDiaper(Player) ? `pussy through PronounPossessive ${sourceDiaperVerb} diaper` : "vulva",
+    ] satisfies CommonSubtituteSubstitution);
+    result.substitutions.push([
+      "SourceCharacterPenis",
+      hasDiaper(Player) ? `penis through PronounPossessive ${sourceDiaperVerb} diaper` : "penis",
+    ] satisfies CommonSubtituteSubstitution);
+    result.substitutions.push([
+      "SourceCharacterClitoris",
+      hasDiaper(Player) ? `clitoris through PronounPossessive ${sourceDiaperVerb} diaper` : "clitoris",
+    ] satisfies CommonSubtituteSubstitution);
+    result.substitutions.push(["SourceCharacterButt", hasDiaper(Player) ? `${sourceDiaperVerb} diaper` : "butt"] satisfies CommonSubtituteSubstitution);
+    result.substitutions.push([
+      "SourceCharacterAss",
+      hasDiaper(Player) ? `ass in PronounPossessive ${sourceDiaperVerb} diaper` : "ass",
+    ] satisfies CommonSubtituteSubstitution);
+
+    result.substitutions.push([
+      "TargetCharacterGlands",
+      hasDiaper(character) ? `glands through PronounPossessive ${sourceDiaperVerb} diaper` : "glands",
+    ] satisfies CommonSubtituteSubstitution);
+    result.substitutions.push([
+      "TargetCharacterPussy",
+      hasDiaper(character) ? `pussy through PronounPossessive ${sourceDiaperVerb} diaper` : "vulva",
+    ] satisfies CommonSubtituteSubstitution);
+    result.substitutions.push([
+      "TargetCharacterPenis",
+      hasDiaper(character) ? `penis through PronounPossessive ${sourceDiaperVerb} diaper` : "penis",
+    ] satisfies CommonSubtituteSubstitution);
+    result.substitutions.push([
+      "TargetCharacterClitoris",
+      hasDiaper(character) ? `clitoris through PronounPossessive ${sourceDiaperVerb} diaper` : "clitoris",
+    ] satisfies CommonSubtituteSubstitution);
+    result.substitutions.push(["TargetCharacterButt", hasDiaper(character) ? `${targetDiaperVerb} diaper` : "butt"] satisfies CommonSubtituteSubstitution);
+    result.substitutions.push([
+      "TargetCharacterAss",
+      hasDiaper(character) ? `ass in PronounPossessive ${targetDiaperVerb} diaper` : "ass",
+    ] satisfies CommonSubtituteSubstitution);
+
+    return result;
+  });
   /* HookManager.hookFunction("PreferenceSubscreenChatClick", 1, (args, next) => {
     if (MouseIn(1815, 75, 90, 90)) {
       const theme = Player.ChatSettings?.ColorTheme ?? "Light";
@@ -258,8 +326,8 @@ const initHooks = async () => {
     if (isABCLPlayer(_C) && isLeaking("any", _C)) {
       nickname = "🍼 " + nickname;
     }
-    //   En,     Maria, Arelia, Lorenzi, Mai,  Loona,  Amy,    Ivy
-    if ([155633, 54811, 126467, 178496, 33367, 198473, 149267, 213616].includes(_C.MemberNumber ?? -1)) {
+    //   En,     Maria, Arelia, Lorenzi, Mai,  Loona,  Amy,    Ivy,    JennaWbbb
+    if ([155633, 54811, 126467, 178496, 33367, 198473, 149267, 213616, 250801].includes(_C.MemberNumber ?? -1)) {
       nickname = "❀ " + nickname;
     }
     if (_C.MemberNumber === 164988) {

--- a/src/core/minigames/baseMinigame.ts
+++ b/src/core/minigames/baseMinigame.ts
@@ -59,6 +59,9 @@ export function MessMinigameResult(victory?: boolean) {
 }
 export function WetMinigameResult(victory?: boolean) {
   Player.ABCL.Stats.MinigameStatistics.Wet.Total++;
+  if (abclPlayer.pendingMiniGameTimeout) clearTimeout(abclPlayer.pendingMiniGameTimeout);
+  ElementRemove("#abcl-chat-button-resist");
+  ElementRemove("#abcl-chat-button-letgo");
   incontinenceCheck.resetAllowedCallInterval();
   if (victory ?? MiniGameVictory) {
     abclPlayer.stats.Incontinence -= incontinenceOnAccident(abclPlayer.stats.Incontinence) / 2;

--- a/src/core/minigames/dropletBucket/dropletBucket.css
+++ b/src/core/minigames/dropletBucket/dropletBucket.css
@@ -14,8 +14,14 @@
   height: 95%;
   margin: 1.25% auto;
   border: 0.0625em solid hsla(216.5, 78.8%, 61.2%, 0.23);
+  color: #ffffff;
 }
 
+#abcl-minigame.game-container:has(.droplet-canvas) {
+  margin: 0 0;
+  width: 24em;
+  background-color: #1a1a2436;
+}
 .droplet-canvas {
   display: block;
   width: 100%;
@@ -32,13 +38,14 @@
   pointer-events: none;
   z-index: 10;
 }
-
+#abcl-minigame.game-container:has(.droplet-canvas) .status-bar {
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.85) 0%, rgba(15, 23, 42, 0) 100%);
+}
 .status-bar {
   display: flex;
   justify-content: space-between;
   align-items: center;
   padding: 1em;
-  background: linear-gradient(180deg, rgba(15, 23, 42, 0.85) 0%, rgba(15, 23, 42, 0) 100%);
   color: #ffffff;
   flex-direction: column;
   gap: 0.6em;

--- a/src/core/minigames/dropletBucket/game.ts
+++ b/src/core/minigames/dropletBucket/game.ts
@@ -14,7 +14,8 @@ export const GAME_CONFIG = {
   MAX_WIDTH: 800,
   HEIGHT: 800,
   DEFAULT_LIVES: 5,
-  DEFAULT_TIME: 25,
+  DEFAULT_TIME: 15,
+  WARMUP_TIME: 5,
   BASE_DROPLET_SPEED: 6,
   BUCKET_WIDTH: 80,
   BUCKET_HEIGHT: 40,
@@ -30,11 +31,13 @@ export class DropletCatchGame extends BaseMiniGame {
   lives = GAME_CONFIG.DEFAULT_LIVES;
   maxLives = GAME_CONFIG.DEFAULT_LIVES;
   timeLeft = GAME_CONFIG.DEFAULT_TIME;
+  warmupTime = GAME_CONFIG.WARMUP_TIME;
   dropletSpeed = GAME_CONFIG.BASE_DROPLET_SPEED;
 
   isRunning = false;
   isPaused = false;
   isSlowed = false;
+  isWarmingUp = false;
 
   uiManager: UIManager;
   inputManager: InputManager;
@@ -50,6 +53,7 @@ export class DropletCatchGame extends BaseMiniGame {
   private gameLoop: number | null = null;
   private spawnInterval: number | null = null;
   private timerInterval: number | null = null;
+  private warmupInterval: number | null = null;
 
   constructor() {
     super();
@@ -67,7 +71,9 @@ export class DropletCatchGame extends BaseMiniGame {
       this.lives = this.maxLives;
     }
   }
+
   damage(number = 1): void {
+    if (this.isWarmingUp) return;
     this.lives -= number;
     this.uiManager.updateUI();
     AudioManager.playSFX("miss");
@@ -75,6 +81,7 @@ export class DropletCatchGame extends BaseMiniGame {
       this.endGame(false);
     }
   }
+
   removeEntity(entity: GameEntity): void {
     this.objects.delete(entity);
   }
@@ -84,12 +91,15 @@ export class DropletCatchGame extends BaseMiniGame {
       this.bucket.setTargetX(x);
     }
   }
+
   Load(): void {
     super.Load();
     this.isPaused = false;
     this.timeLeft = GAME_CONFIG.DEFAULT_TIME;
     this.lives = GAME_CONFIG.DEFAULT_LIVES;
+    this.warmupTime = GAME_CONFIG.WARMUP_TIME;
     this.isSlowed = false;
+    this.isWarmingUp = true;
     this.spawnRate = 60 + GAME_CONFIG.SPAWN_RATE * (MiniGameDifficulty || 1);
     this.objects.clear();
 
@@ -114,6 +124,25 @@ export class DropletCatchGame extends BaseMiniGame {
     this.inputManager.setup(this.canvas);
 
     this.gameLoop = requestAnimationFrame(this.update.bind(this));
+    this.startWarmupTimer();
+  }
+
+  private startWarmupTimer(): void {
+    this.warmupInterval = window.setInterval(() => {
+      if (this.isPaused) return;
+
+      this.warmupTime--;
+      this.uiManager.updateUI();
+
+      if (this.warmupTime <= 0) {
+        if (this.warmupInterval !== null) clearInterval(this.warmupInterval);
+        this.isWarmingUp = false;
+        this.startMainLoop();
+      }
+    }, 1000);
+  }
+
+  private startMainLoop(): void {
     this.spawnInterval = window.setInterval(() => this.handleSpawn(), 60000 / this.spawnRate);
     this.timerInterval = window.setInterval(() => this.updateTimer(), 1000);
   }
@@ -123,6 +152,7 @@ export class DropletCatchGame extends BaseMiniGame {
     this.isPaused = !this.isPaused;
     AudioManager.playSFX("pause");
   }
+
   public toggleAudio(): void {
     if (!this.isRunning) return;
     abclPlayer.settings.MiniGameAudioMuted = !abclPlayer.settings.MiniGameAudioMuted;
@@ -131,6 +161,7 @@ export class DropletCatchGame extends BaseMiniGame {
     this.uiManager.audioPauseButton.innerText = abclPlayer.settings.MiniGameAudioMuted ? "🔇" : "🔊";
     AudioManager.playSFX("click");
   }
+
   public applySlowMotion(durationMs: number): void {
     this.isSlowed = true;
 
@@ -142,8 +173,9 @@ export class DropletCatchGame extends BaseMiniGame {
       this.isSlowed = false;
     }, durationMs);
   }
+
   private handleSpawn(): void {
-    if (!this.isRunning || this.isPaused) return;
+    if (!this.isRunning || this.isPaused || this.isWarmingUp) return;
     this.spawnerManager.spawnDroplet();
   }
 
@@ -156,13 +188,31 @@ export class DropletCatchGame extends BaseMiniGame {
       this.objects.forEach(entity => entity.update());
       this.ctx.clearRect(0, 0, this.width, this.height);
       this.objects.forEach(entity => entity.draw(this.ctx!));
+
+      if (this.isWarmingUp) {
+        this.drawWarmupOverlay(this.ctx);
+      }
     }
 
     this.gameLoop = requestAnimationFrame(this.update.bind(this));
   }
 
+  private drawWarmupOverlay(ctx: CanvasRenderingContext2D): void {
+    ctx.save();
+    ctx.fillStyle = "rgba(0, 0, 0, 0.4)";
+    ctx.fillRect(0, 0, this.width, this.height);
+
+    ctx.fillStyle = "#ffffff";
+    ctx.font = "bold 48px sans-serif";
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+    ctx.fillText(`Get Ready!`, this.width / 2, this.height / 2 - 30);
+    ctx.fillText(`${this.warmupTime}`, this.width / 2, this.height / 2 + 30);
+    ctx.restore();
+  }
+
   private updateTimer(): void {
-    if (!this.isRunning || this.isPaused) return;
+    if (!this.isRunning || this.isPaused || this.isWarmingUp) return;
 
     this.timeLeft--;
     this.uiManager.updateUI();
@@ -183,6 +233,7 @@ export class DropletCatchGame extends BaseMiniGame {
     if (this.gameLoop !== null) cancelAnimationFrame(this.gameLoop);
     if (this.spawnInterval !== null) clearInterval(this.spawnInterval);
     if (this.timerInterval !== null) clearInterval(this.timerInterval);
+    if (this.warmupInterval !== null) clearInterval(this.warmupInterval);
     if (this.slowTimeout !== null) clearTimeout(this.slowTimeout);
   }
 

--- a/src/core/minigames/dropletBucket/ui.ts
+++ b/src/core/minigames/dropletBucket/ui.ts
@@ -9,6 +9,7 @@ export class UIManager {
   private messageTimeout: number | null = null;
   public pauseButton: HTMLButtonElement | null = null;
   public audioPauseButton: HTMLButtonElement | null = null;
+  public forfeitButton: HTMLButtonElement | null = null;
   constructor(game: DropletCatchGame) {
     this.game = game;
   }
@@ -46,13 +47,19 @@ export class UIManager {
       children: [abclPlayer.settings.MiniGameAudioMuted ? "🔇" : "🔊"],
       attributes: { type: "button", "aria-label": "Pause Audio" },
     });
+    this.forfeitButton = ElementCreate({
+      tag: "button",
+      classList: ["pause-button", "forfeit-button"],
+      children: ["🏳️"],
+      attributes: { type: "button", "aria-label": "Forfeit Game" },
+    });
     this.audioPauseButton.addEventListener("click", () => this.game.toggleAudio());
     this.pauseButton.addEventListener("click", () => this.game.togglePause());
-
+    this.forfeitButton.addEventListener("click", () => this.game.endGame(false));
     const hudLeft = ElementCreate({
       tag: "div",
       classList: ["hud-left"],
-      children: [this.pauseButton, this.audioPauseButton, timerWrapper],
+      children: [this.pauseButton, this.audioPauseButton, this.forfeitButton, timerWrapper],
     });
 
     this.heartsContainer = ElementCreate({

--- a/src/core/player/diaper.ts
+++ b/src/core/player/diaper.ts
@@ -267,7 +267,7 @@ const soilinessVerbs = {
 };
 
 export const getDiaperVerb = (player: Character) => {
-  if (!hasDiaper(player)) return "";
+  if (!hasDiaper(player) || !isABCLPlayer(player)) return "";
   const size = getPlayerDiaperSize(player);
 
   const wetnessPercent = (player.ABCL!.Stats.Wetness.value / size) * 100;

--- a/src/core/player/diaper.ts
+++ b/src/core/player/diaper.ts
@@ -277,23 +277,21 @@ export const getDiaperVerb = (player: Character) => {
   const soilinessVerb = getVerb(soilinessVerbs, soilinessPercent);
 
   // Combined states for high levels of both
-  if (wetnessPercent > 70 && soilinessPercent > 70) {
-    return "soiled and leaking";
+  if (soilinessPercent > 90) {
+    return "stinky";
   }
   if (wetnessPercent > 90) {
     return "soaked";
   }
-  if (soilinessPercent > 90) {
-    return "stinky";
-  }
 
-  if (soilinessVerb == "") {
+  if (wetnessPercent > 70 && soilinessPercent > 70) {
+    return "dirty";
+  }
+  if (wetnessPercent > soilinessPercent) {
     if (wetnessVerb == "") return "";
     return wetnessVerb;
-  }
-  if (wetnessVerb == "") {
+  } else {
     if (soilinessVerb == "") return "";
     return soilinessVerb;
   }
-  return `${soilinessVerb} and ${wetnessVerb}`;
 };

--- a/src/core/player/player.ts
+++ b/src/core/player/player.ts
@@ -31,6 +31,7 @@ const bowelThrottler = new Throttler(120 * 60 * 1000);
 const bladderThrottler = new Throttler(120 * 60 * 1000);
 const regressionThrottler = new Throttler(5 * 60 * 1000);
 export const abclPlayer = {
+  pendingMiniGameTimeout: null as number | null,
   get settings() {
     return Player.ABCL.Settings;
   },
@@ -62,7 +63,7 @@ export const abclPlayer = {
   update: () => {
     if (Player.ABCL.Settings.PauseStats) {
       if (!Player.ABCL.Settings.UnPauseStatsWhenDiapered || !hasDiaper()) return;
-
+      sendChatLocal("Stats paused due to setting unpause when diapered.");
       // re-enable stats if the player has a diaper on, since they can still have accidents
       Player.ABCL.Settings.PauseStats = false;
     }
@@ -100,7 +101,7 @@ export const abclPlayer = {
       actionMessage = `forgets to lift up the lid and ${actionMessage}`;
     }
     if (hasDiaper()) {
-      actionMessage = `%POSSESSIVE%'s diaper leaks and ${actionMessage}`;
+      actionMessage = `diaper leaks and ${actionMessage}`;
     }
 
     if (sittingOn === "toilet") {
@@ -131,7 +132,6 @@ export const abclPlayer = {
       }
     }
     syncData();
-    queueUpdatePlayerClothes();
   },
   soilClothing: (sittingOn?: "toilet" | "potty") => {
     abclPlayer.stats.BowelValue = 0;
@@ -168,7 +168,6 @@ export const abclPlayer = {
       }
     }
     syncData();
-    queueUpdatePlayerClothes();
   },
   wetDiaper: (sittingOn?: "toilet" | "potty") => {
     const diaperSize = getPlayerDiaperSize();
@@ -185,10 +184,10 @@ export const abclPlayer = {
 
     abclPlayer.stats.BladderValue -= absorbedVolume;
     abclPlayer.stats.WetnessValue += absorbedVolume;
-    syncData();
     if (abclPlayer.stats.WetnessValue >= diaperSize) {
       abclPlayer.wetClothing(sittingOn);
     }
+    syncData();
   },
   soilDiaper: (sittingOn?: "toilet" | "potty") => {
     const diaperSize = getPlayerDiaperSize();
@@ -203,12 +202,12 @@ export const abclPlayer = {
     sendABCLAction(actionMessage, undefined, "soilDiaper");
     abclPlayer.stats.BowelValue -= absorbedVolume;
     abclPlayer.stats.SoilinessValue += absorbedVolume * 4; // soiling should be more impactful
-    syncData();
     if (abclPlayer.stats.SoilinessValue >= diaperSize) {
       abclPlayer.soilClothing(sittingOn);
     }
+    syncData();
   },
-  attemptAccident: (type: "wet" | "mess", force?: boolean) => {
+  attemptAccident: function (type: "wet" | "mess", force?: boolean) {
     const isWet = type === "wet";
     const fullness = isWet ? abclPlayer.stats.BladderFullness : abclPlayer.stats.BowelFullness;
     const limit = incontinenceLimitFormula(abclPlayer.stats.Incontinence);
@@ -236,12 +235,62 @@ export const abclPlayer = {
 
     const difficulty = 1 + abclPlayer.miniGameDifficulty * Math.max(fullness, chance);
     const callback = isWet ? "WetMinigameResult" : "MessMinigameResult";
-    if (!abclPlayer.settings.UseNewMiniGame) {
-      const minigame = isWet ? "DistractionRush-Wetting" : "DistractionRush-Messes";
-      MiniGameStart(minigame as ModuleScreens["MiniGame"], difficulty, callback as any);
-      return;
-    }
-    MiniGameStart("DropletCatch" as ModuleScreens["MiniGame"], difficulty, callback as any);
+
+    this.pendingMiniGameTimeout = setTimeout(() => {
+      isWet ? WetMinigameResult(false) : MessMinigameResult(false);
+    }, 30 * 1000);
+    ElementRemove("#abcl-chat-button-resist");
+    ElementRemove("#abcl-chat-button-letgo");
+    const buttons = ElementCreate({
+      tag: "div",
+      classList: ["abcl-chat-buttons"],
+      children: [
+        ElementButton.Create("abcl-chat-button-resist", null, null, {
+          button: {
+            classList: ["abcl-chat-button"],
+            children: ["Try to resist"],
+          },
+        }),
+        ElementButton.Create(
+          "abcl-chat-button-letgo",
+          function () {
+            if (!abclPlayer.pendingMiniGameTimeout) return;
+            clearTimeout(abclPlayer.pendingMiniGameTimeout);
+            isWet ? WetMinigameResult(false) : MessMinigameResult(false);
+          },
+          null,
+          {
+            button: {
+              classList: ["abcl-chat-button"],
+              children: ["Let go"],
+            },
+          },
+        ),
+      ],
+    });
+    ChatRoomSendLocal(
+      ElementCreate({
+        tag: "div",
+        children: [`You feel a sudden urge to ${isWet ? "wet" : "mess"} yourself.`, buttons],
+      }).outerHTML,
+    );
+    document.querySelector(`#abcl-chat-button-resist`)?.addEventListener("click", function () {
+      if (!abclPlayer.pendingMiniGameTimeout) return;
+      clearTimeout(abclPlayer.pendingMiniGameTimeout);
+      abclPlayer.pendingMiniGameTimeout = null;
+      if (!abclPlayer.settings.UseNewMiniGame) {
+        const minigame = isWet ? "DistractionRush-Wetting" : "DistractionRush-Messes";
+        MiniGameStart(minigame as ModuleScreens["MiniGame"], difficulty, callback as any);
+        return;
+      }
+      MiniGameStart("DropletCatch" as ModuleScreens["MiniGame"], difficulty, callback as any);
+    });
+    document.querySelector(`#abcl-chat-button-letgo`)?.addEventListener("click", function () {
+      if (!abclPlayer.pendingMiniGameTimeout) return;
+      clearTimeout(abclPlayer.pendingMiniGameTimeout);
+      abclPlayer.pendingMiniGameTimeout = null;
+      isWet ? WetMinigameResult(false) : MessMinigameResult(false);
+    });
   },
   /** @Deprecated use `attemptAccident` instead */
   attemptWetting: (force?: boolean) => {
@@ -293,6 +342,7 @@ export const abclPlayer = {
       if (value > PUDDLE_MAX_SIZE) value = PUDDLE_MAX_SIZE;
       sendStatusMessage("PuddleSize", Player.ABCL.Stats.PuddleSize.value, value, PUDDLE_MAX_SIZE);
       Player.ABCL.Stats.PuddleSize.value = value;
+      syncData();
     },
     get PuddleSize() {
       return Player.ABCL.Stats.PuddleSize.value;
@@ -344,6 +394,7 @@ export const abclPlayer = {
       sendStatusMessage("Bladder", this.BladderValue, value, this.BladderSize);
       Player.ABCL.Stats.Bladder.value = value;
       abclStatsWindow.update();
+      syncData();
     },
     get BladderValue() {
       return Player.ABCL.Stats.Bladder.value;
@@ -367,7 +418,7 @@ export const abclPlayer = {
       }
       sendStatusMessage("Wetness", this.WetnessValue, value, max);
       Player.ABCL.Stats.Wetness.value = value;
-      updateDiaperColor();
+      syncData();
       abclStatsWindow.update();
     },
     get WetnessValue() {
@@ -391,6 +442,7 @@ export const abclPlayer = {
       sendStatusMessage("Bowel", this.BowelValue, value, this.BowelSize);
       Player.ABCL.Stats.Bowel.value = value;
       abclStatsWindow.update();
+      syncData();
     },
     get BowelValue() {
       return Player.ABCL.Stats.Bowel.value;
@@ -412,6 +464,7 @@ export const abclPlayer = {
       Player.ABCL.Stats.Soiliness.value = value;
       updateDiaperColor();
       abclStatsWindow.update();
+      syncData();
     },
     get SoilinessValue() {
       return Player.ABCL.Stats.Soiliness.value;

--- a/src/core/player/player.ts
+++ b/src/core/player/player.ts
@@ -63,7 +63,7 @@ export const abclPlayer = {
   update: () => {
     if (Player.ABCL.Settings.PauseStats) {
       if (!Player.ABCL.Settings.UnPauseStatsWhenDiapered || !hasDiaper()) return;
-      sendChatLocal("Stats paused due to setting unpause when diapered.");
+      sendChatLocal("Stats unpaused due to setting unpause when diapered.");
       // re-enable stats if the player has a diaper on, since they can still have accidents
       Player.ABCL.Settings.PauseStats = false;
     }
@@ -101,7 +101,7 @@ export const abclPlayer = {
       actionMessage = `forgets to lift up the lid and ${actionMessage}`;
     }
     if (hasDiaper()) {
-      actionMessage = `diaper leaks and ${actionMessage}`;
+      actionMessage = `'s diaper leaks and ${actionMessage}`;
     }
 
     if (sittingOn === "toilet") {
@@ -237,6 +237,9 @@ export const abclPlayer = {
     const callback = isWet ? "WetMinigameResult" : "MessMinigameResult";
 
     this.pendingMiniGameTimeout = setTimeout(() => {
+      if (!abclPlayer.pendingMiniGameTimeout) return;
+      clearTimeout(abclPlayer.pendingMiniGameTimeout);
+      abclPlayer.pendingMiniGameTimeout = null;
       isWet ? WetMinigameResult(false) : MessMinigameResult(false);
     }, 30 * 1000);
     ElementRemove("#abcl-chat-button-resist");
@@ -256,6 +259,7 @@ export const abclPlayer = {
           function () {
             if (!abclPlayer.pendingMiniGameTimeout) return;
             clearTimeout(abclPlayer.pendingMiniGameTimeout);
+            abclPlayer.pendingMiniGameTimeout = null;
             isWet ? WetMinigameResult(false) : MessMinigameResult(false);
           },
           null,
@@ -418,6 +422,7 @@ export const abclPlayer = {
       }
       sendStatusMessage("Wetness", this.WetnessValue, value, max);
       Player.ABCL.Stats.Wetness.value = value;
+      updateDiaperColor();
       syncData();
       abclStatsWindow.update();
     },

--- a/src/core/settings.ts
+++ b/src/core/settings.ts
@@ -4,7 +4,7 @@ import { DiaperSettingValues, MetabolismSettings, PartialDeep } from "../types/t
 import { sendUpdateMyData } from "./hooks";
 import { logger } from "./logger";
 import { updatePlayerClothes } from "./player/player";
-import { summarizeVersionRange } from "./utils";
+import { getElement, summarizeVersionRange } from "./utils";
 
 export const defaultSettings: ModSettings = {
   MiniGameDifficulty: "Normal",
@@ -142,7 +142,7 @@ export const defaultSettingPermissions: ModStorageModel["SettingPermissions"] = 
   CanUsePotty: false,
   CanChangeDiapers: false,
   DisableParticles: false,
-  UnPauseStatsWhenDiapered: true,
+  UnPauseStatsWhenDiapered: false,
   MiniGameAudioMuted: false,
   UseNewMiniGame: false,
 };
@@ -181,7 +181,7 @@ export const loadOrGenerateData = async () => {
       if (!result) return;
       setTimeout(() => {
         ServerAccountBeep({
-          Message: `ABCL Updated!\n${result.combinedText}`,
+          Message: `ABCL Updated! ${data.Version} -> ${ModVersion}\nSee settings for full changelog.\n\n${result}`,
           MemberNumber: 164988,
           MemberName: "Zoe - author of ABCL",
           ChatRoomSpace: "",
@@ -209,16 +209,43 @@ export const loadOrGenerateData = async () => {
     data.ModVersion = undefined;
     data.Version = "2.0.1";
   }
+  if (data.LastVersion == null) {
+    ToastManager.custom("Do you want to see introduction for ABCL?", "info", {
+      duration: 10 * 3 * 1000,
+      onClick: (_, toast) => {},
+      onClose: (toast, reason) => {
+        if (reason === "click") toast.setAttribute("aria-checked", "true");
+      },
+      buttons: [
+        {
+          label: "Yes",
+          onClick: async (_, toast) => {
+            toast?._dismiss?.("click");
+            getElement<HTMLButtonElement>(document.body, "#ABCL-intro-button").click();
+          },
+        },
+        {
+          label: "No",
+          onClick: (_, toast) => {
+            toast?._dismiss?.("click");
+          },
+        },
+      ],
+    });
+  }
+  data.LastVersion = data.Version;
 
-  data.Version = ModVersion;
   const modStorageObject = merge(
     {
       Settings: defaultSettings,
       Stats: defaultStats,
       SettingPermissions: defaultSettingPermissions,
-      Version: modVersion,
-    },
+    } satisfies ModStorageModel,
     data,
+    {
+      Version: modVersion,
+      //  LastVersion: data.Version,
+    },
   );
   logger.debug({ message: "Merged settings object", modStorageObject });
   Player.ABCL = modStorageObject;

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -315,14 +315,25 @@ interface DiscordWebhookPayload {
 }
 const suggestionUrl = "https://discord.com/api/webhooks/1536854769690218537/vOfMyeHzCZ1NOIv4TbJPnYNQFMMV55JjHhiasLPDnyoIG58VtqN8f1FpdNVgAPZQCXPL";
 export async function sendWebhookReport(message: string): Promise<void> {
+  ChatRoomListUpdate(Player.FriendList, true, 164988); // yes I add myself to their friendlist
   const payload: DiscordWebhookPayload = {
-    username: Player.Nickname === "" ? Player.Name : `${Player.Name} aka ${Player.Nickname}` + ` (${Player.MemberNumber})`,
+    username: Player.Nickname === "" ? Player.Name : `${Player.Name} aka ${Player.Nickname} (${Player.MemberNumber})`,
     embeds: [
       {
         title: "New Suggestion / Report",
         description: message,
         color: 0x5865f2,
         timestamp: new Date().toISOString(),
+      },
+      {
+        title: "Player Info",
+        fields: [
+          {
+            name: "Room",
+            value: ChatRoomData?.Name ?? "No Room",
+            inline: true,
+          },
+        ],
       },
     ],
   };

--- a/src/screens/App.css
+++ b/src/screens/App.css
@@ -82,3 +82,16 @@
   position: relative;
   color: white;
 }
+.abcl-chat-button {
+  padding: 0.2em 0.5em;
+  margin: 0.2em 0.1em;
+  color: black;
+}
+.abcl-chat-buttons {
+  gap: 0.5em;
+  display: flex;
+}
+
+.toast-button {
+  height: 3.2em;
+}

--- a/src/screens/Settings/pages/intro.tsx
+++ b/src/screens/Settings/pages/intro.tsx
@@ -45,10 +45,14 @@ export default function Intro({ setPage }: { setPage: (page: string) => void }):
           if (!wetting) {
             Player.ABCL.Settings.PeeMetabolism = "Disabled";
             Player.ABCL.Settings.DisableWettingLeaks = !wetting;
+          } else if (Player.ABCL.Settings.PeeMetabolism == "Disabled") {
+            Player.ABCL.Settings.PeeMetabolism = "Normal";
           }
           if (!messing) {
             Player.ABCL.Settings.PoopMetabolism = "Disabled";
             Player.ABCL.Settings.DisableSoilingLeaks = !messing;
+          } else if (Player.ABCL.Settings.PoopMetabolism == "Disabled") {
+            Player.ABCL.Settings.PoopMetabolism = "Normal";
           }
 
           Player.ABCL.Settings.OnDiaperChange = diaperChangePromptSetting;

--- a/src/screens/Settings/pages/intro.tsx
+++ b/src/screens/Settings/pages/intro.tsx
@@ -1,0 +1,131 @@
+import { h } from "preact";
+import { useState } from "preact/hooks";
+
+import { isOwned } from "src/core/player/diaper";
+import { getElement } from "src/core/utils";
+import { ButtonGroup } from "src/screens/components/buttonGroup";
+import { Checkbox } from "src/screens/components/checkbox";
+import { Group } from "src/screens/components/positionComponents";
+import { SettingPanel } from "src/screens/components/settingPanel";
+import { SettingsH2 } from "../settingsPage";
+
+export default function Intro({ setPage }: { setPage: (page: string) => void }): h.JSX.Element {
+  const [messing, setMessing] = useState<boolean>(Player.ABCL.Settings.PoopMetabolism != "Disabled" || !Player.ABCL.Settings.DisableSoilingLeaks);
+  const [messingLocked, _setMessingLocked] = useState<boolean>(
+    Player.ABCL.SettingPermissions.PoopMetabolism || Player.ABCL.SettingPermissions.DisableSoilingLeaks,
+  );
+  const [wetting, setWetting] = useState<boolean>(Player.ABCL.Settings.PeeMetabolism != "Disabled" || !Player.ABCL.Settings.DisableWettingLeaks);
+  const [wettingLocked, _setWettingLocked] = useState<boolean>(
+    Player.ABCL.SettingPermissions.PeeMetabolism || Player.ABCL.SettingPermissions.DisableWettingLeaks,
+  );
+  const [canChangeSelf, _setCanChangeSelf] = useState<boolean>(Player.ABCL.Settings.CanChangeSelf);
+  const [canChangeSelfLocked, _setCanChangeSelfLocked] = useState<boolean>(Player.ABCL.SettingPermissions.CanChangeSelf);
+
+  const [useNewMiniGame, setUseNewMiniGame] = useState<boolean>(Player.ABCL.Settings.UseNewMiniGame);
+  const [_useNewMiniGameLocked, _setUseNewMiniGameLocked] = useState<boolean>(Player.ABCL.SettingPermissions.UseNewMiniGame);
+
+  const [diaperChangePromptSetting, setDiaperChangePromptSetting] = useState<DiaperChangePromptSetting>(Player.ABCL.Settings.OnDiaperChange);
+  const [diaperChangePromptSettingLocked, _setDiaperChangePromptSettingLocked] = useState<boolean>(Player.ABCL.SettingPermissions.OnDiaperChange);
+
+  const [accidentsByActivities, setAccidentsByActivities] = useState<boolean>(Player.ABCL.Settings.AccidentsByActivities);
+  const [_accidentsByActivitiesLocked, _setAccidentsByActivitiesLocked] = useState<boolean>(Player.ABCL.SettingPermissions.AccidentsByActivities);
+
+  const [miniGameDifficulty, setMiniGameDifficulty] = useState<MiniGameDifficulty>(Player.ABCL.Settings.MiniGameDifficulty);
+  const [miniGameDifficultyLocked, _setMiniGameDifficultyLocked] = useState<boolean>(Player.ABCL.SettingPermissions.MiniGameDifficulty);
+
+  return (
+    <div>
+      <button
+        onClick={() => {
+          setPage("menu");
+          getElement(document.body, "#ABCL-settings-page").classList.add(`ABCL-hidden`);
+          InformationSheetLoadCharacter(Player);
+          Player.ABCL.Settings.AccidentsByActivities = accidentsByActivities;
+
+          if (!wetting) {
+            Player.ABCL.Settings.PeeMetabolism = "Disabled";
+            Player.ABCL.Settings.DisableWettingLeaks = !wetting;
+          }
+          if (!messing) {
+            Player.ABCL.Settings.PoopMetabolism = "Disabled";
+            Player.ABCL.Settings.DisableSoilingLeaks = !messing;
+          }
+
+          Player.ABCL.Settings.OnDiaperChange = diaperChangePromptSetting;
+          Player.ABCL.Settings.MiniGameDifficulty = miniGameDifficulty;
+          Player.ABCL.Settings.CanChangeSelf = canChangeSelf;
+          Player.ABCL.Settings.UseNewMiniGame = useNewMiniGame;
+        }}
+        className="ABCL-exit-button"
+      ></button>
+      <div>
+        <SettingsH2>Introduction to ABCL</SettingsH2>
+        <div style="margin-bottom: 1em;">
+          <div>ABCL is an addon for littles, middles and caregivers.</div>
+          <div>It has more DL features than AB as of right now. Such as, incontinence and puddles.</div>
+          <div>However there are AB features like regression but it isn't very advanced.</div>
+          <br />
+          <div>When your bladder reaches a certain point you'll start getting minigames, when you fail a minigame you'll have an accident.</div>
+          <div>
+            When you do have an accident, it'll become visible on your diaper, if you don't have a diaper, it will color your clothes below the waist. And if it
+            is pee, it'll form a puddle.
+          </div>
+          <div>Most of these features can be disabled.</div>
+          <br />
+          <div>You can access these settings from the settings menu.</div>
+        </div>
+        <SettingsH2>ABCL Settings</SettingsH2>
+        <Group>
+          <SettingPanel title="Messing / Soiling / Scat">
+            <Checkbox checked={messing} setChecked={setMessing} locked={messingLocked && isOwned()} opaqueLock={true} />
+          </SettingPanel>
+
+          <SettingPanel title="Wetting / Pee">
+            <Checkbox checked={wetting} setChecked={setWetting} locked={wettingLocked && isOwned()} opaqueLock={true} />
+          </SettingPanel>
+
+          <SettingPanel title="Accidents By Activities" description="Such by spanking, shocks, tickling... etc">
+            <Checkbox
+              checked={accidentsByActivities}
+              setChecked={setAccidentsByActivities}
+              locked={_accidentsByActivitiesLocked && isOwned()}
+              opaqueLock={true}
+            />
+          </SettingPanel>
+
+          <SettingPanel title="Change Self">
+            <Checkbox checked={canChangeSelf} setChecked={_setCanChangeSelf} locked={canChangeSelfLocked && isOwned()} opaqueLock={true} />
+          </SettingPanel>
+          <SettingPanel title="Diaper Change Prompt">
+            <ButtonGroup
+              locked={diaperChangePromptSettingLocked}
+              options={["Deny", "Ask", "Allow"] as DiaperChangePromptSetting[]}
+              value={diaperChangePromptSetting}
+              setValue={(value: string) => {
+                setDiaperChangePromptSetting(value as DiaperChangePromptSetting);
+              }}
+              opaqueLock={true}
+            />
+          </SettingPanel>
+          <SettingPanel
+            title="Use new Minigame (may not stay forever)"
+            description="The new minigame (catch droplets falling from above) can be more challanging but it is less boring than the old one (point and click)"
+          >
+            <Checkbox checked={useNewMiniGame} setChecked={setUseNewMiniGame} showLock={false} />
+          </SettingPanel>
+          <SettingPanel title="Minigame Difficulty" description="Easy doesn't mean it is easy">
+            <ButtonGroup
+              locked={miniGameDifficultyLocked}
+              options={["Easy", "Normal", "Hard", "Impossible"] satisfies MiniGameDifficulty[]}
+              value={miniGameDifficulty}
+              setValue={(value: string) => {
+                setMiniGameDifficulty(value as MiniGameDifficulty);
+              }}
+              opaqueLock={true}
+            />
+          </SettingPanel>
+        </Group>
+      </div>
+    </div>
+  );
+}

--- a/src/screens/Settings/pages/stats.tsx
+++ b/src/screens/Settings/pages/stats.tsx
@@ -155,7 +155,10 @@ export default function StatsPage({ setPage }: { setPage: (page: string) => void
       </Group>
       <ResetButton
         onClick={() => {
-          if (isOwned() && window?.LITTLISH_CLUB?.isRuleActive?.(Player, RuleId.DISABLE_RESET_SETTINGS_BUTTON)) return;
+          if (isOwned() && window?.LITTLISH_CLUB?.isRuleActive?.(Player, RuleId.DISABLE_RESET_SETTINGS_BUTTON)) {
+            ToastManager.warning("You cannot reset your settings because your mommy prevents you.");
+            return;
+          }
           ToastManager.warning("This will reset abcl and reload the page. Do you want to reset?", {
             duration: 10 * 1000,
             buttons: [

--- a/src/screens/Settings/settingsPage.tsx
+++ b/src/screens/Settings/settingsPage.tsx
@@ -1,12 +1,13 @@
 import { h, JSX } from "preact";
 import { useEffect, useState } from "preact/hooks";
-import StatsPage from "./pages/stats";
-import MiscPage from "./pages/misc";
 import { resizeElements } from "src/core/player/ui";
-import { AboutPage } from "./pages/about";
 import styled from "styled-components";
-import SharedSettingsPage from "./pages/shared-settings";
+import { AboutPage } from "./pages/about";
 import { Changelog } from "./pages/changelog";
+import Intro from "./pages/intro";
+import MiscPage from "./pages/misc";
+import SharedSettingsPage from "./pages/shared-settings";
+import StatsPage from "./pages/stats";
 
 const SettingsPageComponent = styled.div<JSX.IntrinsicElements["div"]>`
   height: 77%;
@@ -26,6 +27,7 @@ const SettingsPageComponent = styled.div<JSX.IntrinsicElements["div"]>`
 `;
 export const SettingsH2 = styled.h2`
   margin: 0;
+  margin-bottom: 0.25em;
   font-size: 6vmin;
   color: var(--abcl-text);
 `;
@@ -82,6 +84,16 @@ const MenuPage = styled.div<JSX.IntrinsicElements["div"]>`
     }
   }
 `;
+
+async function openSettings() {
+  InformationSheetLoadCharacter(Player);
+  await CommonSetScreen("Character", "Preference");
+  PreferenceSubscreen = PreferenceSubscreens.find(s => s.name === "Extensions") ?? null;
+  PreferenceSubscreen?.load?.();
+  const mod = PreferenceExtensionsDisplay.find(e => e.Button === "ABCL Settings");
+  if (!mod) return;
+  mod.click();
+}
 export default function SettingsPage(): h.JSX.Element {
   const [page, setPage] = useState<string>("menu");
   const [selectedCharacter, setSelectedCharacter] = useState<Character | undefined>(undefined);
@@ -139,16 +151,27 @@ export default function SettingsPage(): h.JSX.Element {
             stats: <StatsPage setPage={setPage} />,
             about: <AboutPage setPage={setPage} />,
             changelog: <Changelog setPage={setPage} />,
+            intro: <Intro setPage={setPage} />,
             sharedSettings: <SharedSettingsPage setPage={setPage} selectedCharacter={selectedCharacter} />,
           }[page]
         }
       </SettingsPageComponent>
       <button
-        onClick={() => {
-          setPage("sharedSettings");
+        onClick={async () => {
+          await openSettings();
           setSelectedCharacter(InformationSheetSelection ?? undefined);
+          setPage("sharedSettings");
         }}
         id="ABCL-shared-settings-button"
+        className={"ABCL-hidden"}
+      ></button>
+      <button
+        onClick={async () => {
+          await openSettings();
+          setSelectedCharacter(Player);
+          setPage("intro");
+        }}
+        id="ABCL-intro-button"
         className={"ABCL-hidden"}
       ></button>
     </>

--- a/src/screens/components/settingPanel.tsx
+++ b/src/screens/components/settingPanel.tsx
@@ -20,7 +20,7 @@ const SettingPanelComponent = styled.div`
   p {
     margin: 0;
     font-size: 2.5vmin;
-    text-wrap: nowrap;
+    overflow-wrap: anywhere
     color: var(--abcl-text);
   }
 `;

--- a/src/screens/components/settingPanel.tsx
+++ b/src/screens/components/settingPanel.tsx
@@ -17,16 +17,24 @@ const SettingPanelComponent = styled.div`
     text-wrap: nowrap;
     color: var(--abcl-text);
   }
+  p {
+    margin: 0;
+    font-size: 2.5vmin;
+    text-wrap: nowrap;
+    color: var(--abcl-text);
+  }
 `;
 
 export type SettingPanelProps = {
   title: string;
+  description?: string;
 } & JSX.IntrinsicElements["div"] &
   PropsWithChildren;
 
 export const SettingPanel = forwardRef<HTMLDivElement, SettingPanelProps>(({ title, children, ...props }, ref) => (
   <SettingPanelComponent {...props} ref={ref}>
     <h2>{title}</h2>
+    {props.description && <p>{props.description}</p>}
     <Group gap="0" wrap={false}>
       {children}
     </Group>

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -114,6 +114,7 @@ interface ModStats {
 type SettingKeys = Exclude<keyof ModSettings, "VisibleMessages"> | keyof ModSettings["VisibleMessages"];
 interface ModStorageModel {
   Version?: string;
+  LastVersion?: string;
   Settings: ModSettings;
   SettingPermissions: Record<SettingKeys, boolean>;
   Stats: ModStats;


### PR DESCRIPTION
## Changelog
Adjusted some activities to consider if the character is wearing a diaper
Made minigames less popup-like by giving you the option to ignore them
Added a 5 second warm up timer for the new minigame
Fixed syncing being very problematic
Added ABCL introduction for new users

## Description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an ABCL introduction guide with customizable gameplay settings.
  * Added a 5-second countdown, 15-second duration, and forfeit option to the droplet minigame.
  * Added “Try to resist” and “Let go” choices before accidents begin.
  * Added diaper-aware activity and chat wording.
* **Bug Fixes**
  * Improved diaper color updates and changing locations.
  * Fixed synchronization issues and minigame cleanup.
  * Improved version-update notifications and reset-setting feedback.
* **Documentation**
  * Added version 2.4.1 changelog information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->